### PR TITLE
Fixed salti path resolution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,17 @@ var NOTFOUND = -1;
 var IDTOKEN = '{:id}';
 
 var defaults = {
-  stripTrailingSlash: true
+  stripTrailingSlash: true,
+  prefix: undefined
 };
 
+
+function stripPrefix(path, prefix) {
+  if (path.indexOf(prefix) === 0) {
+    return path.substring(prefix.length);
+  }
+  return path;
+}
 
 function stripTrailingSlash(path) {
   // single slash '/' is a valid path, it should be ignored
@@ -89,8 +97,11 @@ module.exports = function(dbname, inAcl, callback, options) {
     debug('method: %s url: %s path: %s', req.method, req.url, req.path);
 
     var path = req.path;
+    if (options.prefix) {
+      path = stripPrefix(path, options.prefix);
+    }
     if (options.stripTrailingSlash) {
-      path = stripTrailingSlash(req.path);
+      path = stripTrailingSlash(path);
     }
 
     if (!req.connection.pskRole) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ Salti.defaults = {
   idTokenTemplate: '{:id}'
 };
 
-Salti.thaliPrefix = '/_local/thali_';
+Salti.THALI_PREFIX = '/_local/thali_';
 
 Salti.prototype.init = function () {
   var self = this;
@@ -140,16 +140,16 @@ Salti.prototype.handler = function (request, response, nextHandler) {
 
   else if (pathParts.length === 3 && pathParts[1] === '_local') {
     // Is this a thali {:id}?
-    var isThaliPrefix = this.path.startsWith(Salti.thaliPrefix);
+    var isThaliPrefix = this.path.startsWith(Salti.THALI_PREFIX);
     if (isThaliPrefix) {
       // Is /_local/thali_{:id} authorized?
-      lookupPath = this.dbPrefix + Salti.thaliPrefix +
+      lookupPath = this.dbPrefix + Salti.THALI_PREFIX +
         this.options.idTokenTemplate;
       if (this.lookupPathVerb(paths, lookupPath) !== Salti.PATH_VERB_FOUND) {
         debug('unauthorized thali prefix');
         return this.unauthorized(6);
       }
-      var thaliId = this.path.substring(Salti.thaliPrefix.length);
+      var thaliId = this.path.substring(Salti.THALI_PREFIX.length);
       if (!this.resolveThaliId(thaliId)) {
         debug('unauthorized thali id');
         return this.unauthorized(7);
@@ -244,7 +244,7 @@ Salti.prototype.authorized = function () {
   return;
 };
 
-Salti.message401 = {
+Salti.MESSAGE_401 = {
   success: false,
   message: 'Unauthorized'
 };
@@ -254,7 +254,7 @@ Salti.prototype.unauthorized = function (index) {
     'unauthorized %s: pskRole: %s, path: %s, verb: %s',
     index, this.role, this.path, this.request.method
   );
-  return this.response.status(401).send(Salti.message401);
+  return this.response.status(401).send(Salti.MESSAGE_401);
 };
 
 module.exports = Salti;

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,13 +115,13 @@ Salti.prototype.handler = function (request, response, nextHandler) {
 
   // Next section deals with
   // /{:db}/{:id}, /{:db}/_local/{:id} and /{:db}/{:id}/attachment stuff.
-  var cuttedPath = this.getPathWithoutPrefix();
-  if (!cuttedPath) {
+  var cutPath = this.getPathWithoutPrefix();
+  if (!cutPath) {
     // Required DB Prefix is not valid.
     return this.unauthorized(3);
   }
 
-  var pathParts = cuttedPath.split('/');
+  var pathParts = cutPath.split('/');
   if (pathParts[0] !== '') {
     // Sanity check, the first element should always be empty.
     return this.unauthorized(4);
@@ -141,7 +141,7 @@ Salti.prototype.handler = function (request, response, nextHandler) {
 
   else if (pathParts.length === 3 && pathParts[1] === '_local') {
     // Is this a thali {:id}?
-    var isThaliPrefix = cuttedPath.startsWith(Salti.THALI_PREFIX);
+    var isThaliPrefix = cutPath.startsWith(Salti.THALI_PREFIX);
     if (isThaliPrefix) {
       // Is /_local/thali_{:id} authorized?
       lookupPath = this.dbPrefix + Salti.THALI_PREFIX +
@@ -150,7 +150,7 @@ Salti.prototype.handler = function (request, response, nextHandler) {
         debug('unauthorized thali prefix');
         return this.unauthorized(6);
       }
-      var thaliId = cuttedPath.substring(Salti.THALI_PREFIX.length);
+      var thaliId = cutPath.substring(Salti.THALI_PREFIX.length);
       if (!this.resolveThaliId(thaliId)) {
         debug('unauthorized thali id');
         return this.unauthorized(7);

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,10 @@ if (!String.prototype.startsWith) {
 }
 
 
-function Filter(dbName, acl, thaliIdCallback, options) {
-  // Both Filter(...) and new Filter(...) will work fine.
-  if (!(this instanceof Filter)) {
-    return new Filter(dbName, acl, thaliIdCallback, options);
+function Salti(dbName, acl, thaliIdCallback, options) {
+  // Both Salti(...) and new Salti(...) will work fine.
+  if (!(this instanceof Salti)) {
+    return new Salti(dbName, acl, thaliIdCallback, options);
   }
 
   if (!dbName || typeof dbName !== 'string') {
@@ -38,40 +38,45 @@ function Filter(dbName, acl, thaliIdCallback, options) {
   }
   this.thaliIdCallback = thaliIdCallback;
 
-  this.options = objectAssign({}, Filter.defaults, options);
+  this.options = objectAssign({}, Salti.defaults, options);
 
   this.init();
   return this.handler.bind(this);
 }
 
-Filter.defaults = {
+Salti.defaults = {
   stripTrailingSlash: true,
-  prefix: undefined,
+  dbPrefix: undefined,
   dbPathTemplate: '{:db}',
   idTokenTemplate: '{:id}'
 };
 
-Filter.thaliPrefix = '/_local/thali_';
+Salti.thaliPrefix = '/_local/thali_';
 
-Filter.prototype.init = function () {
+Salti.prototype.init = function () {
   var self = this;
 
   this.dbPath = this.dbName;
-  if (this.options.prefix) {
-    this.dbPath = this.options.prefix + '/' + this.dbPath;
+  if (this.options.dbPrefix) {
+    // DB prefix in options can include leading slash.
+    // We should strip it for DB path.
+    this.dbPath = Salti.stripLeadingSlash(this.options.dbPrefix) + '/' + this.dbPath;
   }
   this.dbPrefix = '/' + this.dbPath;
 
   // Replacing dbPath template (for example {:db}) with dbPath
   var dbPathRE = new RegExp(this.options.dbPathTemplate, 'g');
   this.acl.forEach(function (roleData) {
-    roleData.paths.forEach(function (pathData) {
-      pathData.path = pathData.path.replace(dbPathRE, self.dbPath);
-    });
+    if (roleData.paths) {
+      // If paths exists it will be an array (schema is verified).
+      roleData.paths.forEach(function (pathData) {
+        pathData.path = pathData.path.replace(dbPathRE, self.dbPath);
+      });
+    }
   });
 }
 
-Filter.prototype.handler = function (request, response, nextHandler) {
+Salti.prototype.handler = function (request, response, nextHandler) {
   this.request = request;
   this.response = response;
   this.nextHandler = nextHandler;
@@ -84,7 +89,9 @@ Filter.prototype.handler = function (request, response, nextHandler) {
   this.role = this.request.connection.pskRole;
   debug('pskRole: %s', this.role);
 
-  this.stripTrailingSlash();
+  if (this.options.stripTrailingSlash) {
+    this.path = Salti.stripTrailingSlash(this.path);
+  }
 
   // Role data lookup on ACL.
   var roleIndex = fast.indexOf(this.acl, this.role, 'role');
@@ -93,22 +100,18 @@ Filter.prototype.handler = function (request, response, nextHandler) {
   }
   var paths = this.acl[roleIndex].paths;
 
-  // Path data lookup on paths.
-  var pathIndex = fast.indexOf(paths, this.path, 'path');
-  if (pathIndex !== -1) {
-    var verbs = paths[pathIndex].verbs;
-
-    // Request method lookup on verbs.
-    var verbIndex = fast.indexOf(verbs, this.request.method);
-    if (verbIndex !== -1) {
-      return this.authorized('found rawpath');
-    } else {
-      return this.unauthorized(2);
-    }
+  // Raw paths lookup.
+  var lookupResult = this.lookupPathVerb(paths, this.path);
+  if (lookupResult === Salti.PATH_VERB_FOUND) {
+    return this.authorized('found raw path');
+  } else if (lookupResult === Salti.VERB_NOTFOUND) {
+    // Raw path is found, but verb is not found.
+    return this.unauthorized(2);
   }
 
-  // This section deals with /db/id, /db/_local/id and /db/id/attachment stuff.
+  // Next section deals with /{:db}/{:id}, /{:db}/_local/{:id} and /{:db}/{:id}/attachment stuff.
   if (!this.cutDBPrefix()) {
+    // Required DB Prefix is not valid.
     return this.unauthorized(3);
   }
 
@@ -118,21 +121,105 @@ Filter.prototype.handler = function (request, response, nextHandler) {
     return this.unauthorized(4);
   }
 
-  return this.unauthorized(5);
-}
+  var lookupPath;
 
-Filter.prototype.stripTrailingSlash = function () {
-  if (this.options.stripTrailingSlash) {
-    // Single slash '/' is a valid path, it should be ignored.
-    var lastIndex = this.path.length - 1;
-    if (lastIndex > 0 && this.path[lastIndex] === '/') {
-      debug('ignoring trailing slash for %s', this.path);
-      this.path = this.path.substring(0, lastIndex);
+  if (pathParts.length === 2) {
+    // Is /{:id} authorized?
+    lookupPath = this.dbPrefix + '/' + this.options.idTokenTemplate;
+    if (this.lookupPathVerb(paths, lookupPath) === Salti.PATH_VERB_FOUND) {
+      return this.authorized('found raw path and id');
+    } else {
+      return this.unauthorized(5);
     }
   }
+  
+  else if (pathParts.length === 3 && pathParts[1] === '_local') {
+    // Is this a thali {:id}?
+    var isThaliPrefix = this.path.startsWith(Salti.thaliPrefix);
+    if (isThaliPrefix) {
+      // Is /_local/thali_{:id} authorized?
+      lookupPath = this.dbPrefix + Salti.thaliPrefix + this.options.idTokenTemplate;
+      if (this.lookupPathVerb(paths, lookupPath) !== Salti.PATH_VERB_FOUND) {
+        debug('unauthorized thali prefix');
+        return this.unauthorized(6);
+      }
+      var thaliId = this.path.substring(Salti.thaliPrefix.length);
+      if (!this.resolveThaliId(thaliId)) {
+        debug('unauthorized thali id');
+        return this.unauthorized(7);
+      }
+      debug('passed _thali check');
+    }
+    
+    // Is /_local/{:id} authorized?
+    lookupPath = this.dbPrefix + '/_local/' + this.options.idTokenTemplate;
+    if (this.lookupPathVerb(paths, lookupPath) === Salti.PATH_VERB_FOUND) {
+      return this.authorized('passed _local check');
+    } else {
+      return this.unauthorized(8);
+    }
+  }
+  
+  else if (pathParts.length === 3 && pathParts[2] === 'attachment') {
+    // Is /{:id}/attachment authorized?
+    lookupPath = this.dbPrefix + '/' + this.options.idTokenTemplate + '/attachment';
+    if (this.lookupPathVerb(paths, lookupPath) === Salti.PATH_VERB_FOUND) {
+      return this.authorized('passed attachment check');
+    } else {
+      return this.unauthorized(9);
+    }
+  }
+
+  return this.unauthorized(10);
 }
 
-Filter.prototype.cutDBPrefix = function () {
+Salti.PATH_VERB_FOUND = 0;
+Salti.PATH_NOTFOUND = 1;
+Salti.VERB_NOTFOUND = 2;
+Salti.prototype.lookupPathVerb = function (paths, lookupPath) {
+  // Path data lookup on paths.
+  var pathIndex = fast.indexOf(paths, lookupPath, 'path');
+  if (pathIndex === -1) {
+    debug('path is not found: lookupPath: %s', lookupPath);
+    return Salti.PATH_NOTFOUND;
+  }
+  // Request method lookup on verbs.
+  var verbs = paths[pathIndex].verbs;
+  var verbIndex = fast.indexOf(verbs, this.request.method);
+  if (verbIndex === -1) {
+    debug('verb and path are not found: lookupPath: %s, verb: %s', lookupPath, this.request.method);
+    return Salti.VERB_NOTFOUND;
+  }
+  return Salti.PATH_VERB_FOUND;
+}
+
+Salti.prototype.resolveThaliId = function (thaliId) {
+  if (thaliId.length > 0) {
+    return this.thaliIdCallback(thaliId, this.request);
+  }
+  return false;
+}
+
+Salti.stripLeadingSlash = function (path) {
+  if (path.length > 0 && path[0] === '/') {
+    debug('ignoring leading slash for %s', path);
+    return path.substring(1);
+  }
+  return path;
+}
+Salti.stripTrailingSlash = function (path) {
+  // Single slash '/' is a valid path.
+  // It's slash is leading, not trailing.
+  // We shouldn't strip it.
+  var lastIndex = path.length - 1;
+  if (lastIndex > 0 && path[lastIndex] === '/') {
+    debug('ignoring trailing slash for %s', path);
+    return path.substring(0, lastIndex);
+  }
+  return path;
+}
+
+Salti.prototype.cutDBPrefix = function () {
   var isDbPath = this.path.startsWith(this.dbPrefix);
   if (!isDbPath) {
     return false;
@@ -141,20 +228,20 @@ Filter.prototype.cutDBPrefix = function () {
   return true;
 }
 
-Filter.prototype.authorized = function () {
+Salti.prototype.authorized = function () {
   debug.apply(debug, arguments);
   this.nextHandler();
   return;
 }
 
-Filter.message401 = {
+Salti.message401 = {
   success: false,
   message: 'Unauthorized'
 };
 
-Filter.prototype.unauthorized = function (index) {
+Salti.prototype.unauthorized = function (index) {
   debug('unauthorized %s: pskRole: %s, path: %s, verb: %s', index, this.role, this.path, this.request.method);
-  return this.response.status(401).send(Filter.message401);
+  return this.response.status(401).send(Salti.message401);
 }
 
-module.exports = Filter;
+module.exports = Salti;

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,6 +103,7 @@ module.exports = function (dbname, inAcl, callback, options) {
     if (options.prefix) {
       path = stripPrefix(path, options.prefix);
       if (!path) {
+        debug('unauthorized0: no prefix: %s ', req.path);
         return res.status(401).send(msg401);
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,12 +115,13 @@ Salti.prototype.handler = function (request, response, nextHandler) {
 
   // Next section deals with
   // /{:db}/{:id}, /{:db}/_local/{:id} and /{:db}/{:id}/attachment stuff.
-  if (!this.cutDBPrefix()) {
+  var cuttedPath = this.getPathWithoutPrefix();
+  if (!cuttedPath) {
     // Required DB Prefix is not valid.
     return this.unauthorized(3);
   }
 
-  var pathParts = this.path.split('/');
+  var pathParts = cuttedPath.split('/');
   if (pathParts[0] !== '') {
     // Sanity check, the first element should always be empty.
     return this.unauthorized(4);
@@ -140,7 +141,7 @@ Salti.prototype.handler = function (request, response, nextHandler) {
 
   else if (pathParts.length === 3 && pathParts[1] === '_local') {
     // Is this a thali {:id}?
-    var isThaliPrefix = this.path.startsWith(Salti.THALI_PREFIX);
+    var isThaliPrefix = cuttedPath.startsWith(Salti.THALI_PREFIX);
     if (isThaliPrefix) {
       // Is /_local/thali_{:id} authorized?
       lookupPath = this.dbPrefix + Salti.THALI_PREFIX +
@@ -149,7 +150,7 @@ Salti.prototype.handler = function (request, response, nextHandler) {
         debug('unauthorized thali prefix');
         return this.unauthorized(6);
       }
-      var thaliId = this.path.substring(Salti.THALI_PREFIX.length);
+      var thaliId = cuttedPath.substring(Salti.THALI_PREFIX.length);
       if (!this.resolveThaliId(thaliId)) {
         debug('unauthorized thali id');
         return this.unauthorized(7);
@@ -229,13 +230,12 @@ Salti.stripTrailingSlash = function (path) {
   return path;
 };
 
-Salti.prototype.cutDBPrefix = function () {
+Salti.prototype.getPathWithoutPrefix = function () {
   var isDbPath = this.path.startsWith(this.dbPrefix);
   if (!isDbPath) {
-    return false;
+    return null;
   }
-  this.path = this.path.substring(this.dbPrefix.length);
-  return true;
+  return this.path.substring(this.dbPrefix.length);
 };
 
 Salti.prototype.authorized = function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,10 +52,10 @@ function lookupPathVerb(req, paths, path, lookupPath) {
 }
 
 /** given the path it determines the ID and calls the callback with that ID */
-function getThaliId(path, dbname, callback) {
+function getThaliId(req, path, dbname, callback) {
   var matches = path.match('^(\/' + dbname + '\/_local\/thali_)(.+)');
   if (matches && matches.length === 3) {
-    return callback(matches[2]);
+    return callback(matches[2], req);
   }
   return false;
 }
@@ -173,7 +173,7 @@ module.exports = function(dbname, inAcl, callback, options) {
           return res.status(401).send(msg401);
         }
 
-        if (isThaliPrefix && !getThaliId(path, dbname, callback)) {
+        if (isThaliPrefix && !getThaliId(req, path, dbname, callback)) {
           debug('unauthorized4.thaliCallback: req.Path: %s  path: %s', path, thaliPrefix);
           return res.status(401).send(msg401);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,240 +1,160 @@
 /*jshint -W121 */
 'use strict';
-var assert = require('assert');
-var objectAssign = require('object-assign');
 
+var objectAssign = require('object-assign');
+var jsonValidate = require('jsonschema').validate;
 var debug = require('debug')('thalisalti:acl');
+
+var aclSchema = require('./acl-schema.json');
 var fast = require('./indexOf');
 
-var NOTFOUND = -1;
-var IDTOKEN = '{:id}';
 
-var defaults = {
-  stripTrailingSlash: true
+if (!String.prototype.startsWith) {
+  String.prototype.startsWith = function (searchString, position) {
+    return this.substr(position || 0, searchString.length) === searchString;
+  };
+}
+
+
+function Filter(dbName, acl, thaliIdCallback, options) {
+  // Both Filter(...) and new Filter(...) will work fine.
+  if (!(this instanceof Filter)) {
+    return new Filter(dbName, acl, thaliIdCallback, options);
+  }
+
+  if (!dbName || typeof dbName !== 'string') {
+    throw new Error('invalid configuration - missing dbName');
+  }
+  this.dbName = dbName;
+
+  if (!acl || !aclSchema || !jsonValidate(acl, aclSchema).valid) {
+    throw new Error('invalid configuration - acl is not valid');
+  }
+  // ACL data should be cloned.
+  this.acl = JSON.parse(JSON.stringify(acl));
+
+  if (!thaliIdCallback || typeof thaliIdCallback !== 'function') {
+    throw new Error('invalid configuration - callback is not a function');
+  }
+  this.thaliIdCallback = thaliIdCallback;
+
+  this.options = objectAssign({}, Filter.defaults, options);
+
+  this.init();
+  return this.handler.bind(this);
+}
+
+Filter.defaults = {
+  stripTrailingSlash: true,
+  prefix: undefined,
+  dbPathTemplate: '{:db}',
+  idTokenTemplate: '{:id}'
 };
 
-function stripPrefix(path, prefix) {
-  // prefix is required
-  if (path.indexOf(prefix) === 0) {
-    return path.substring(prefix.length);
+Filter.thaliPrefix = '/_local/thali_';
+
+Filter.prototype.init = function () {
+  var self = this;
+
+  this.dbPath = this.dbName;
+  if (this.options.prefix) {
+    this.dbPath = this.options.prefix + '/' + this.dbPath;
   }
-  return undefined;
+  this.dbPrefix = '/' + this.dbPath;
+
+  // Replacing dbPath template (for example {:db}) with dbPath
+  var dbPathRE = new RegExp(this.options.dbPathTemplate, 'g');
+  this.acl.forEach(function (roleData) {
+    roleData.paths.forEach(function (pathData) {
+      pathData.path = pathData.path.replace(dbPathRE, self.dbPath);
+    });
+  });
 }
 
-function stripTrailingSlash(path) {
-  // single slash '/' is a valid path, it should be ignored
-  var lastIndex = path.length - 1;
-  if (lastIndex > 0 && path[lastIndex] === '/') {
-    debug('ignoring trailing slash for %s', path);
-    return path.substring(0, lastIndex);
+Filter.prototype.handler = function (request, response, nextHandler) {
+  this.request = request;
+  this.response = response;
+  this.nextHandler = nextHandler;
+  this.path = request.path;
+  debug('method: %s, url: %s, path: %s', this.request.method, this.request.url, this.path);
+
+  if (!this.request.connection.pskRole) {
+    return this.unauthorized(0);
   }
-  return path;
+  this.role = this.request.connection.pskRole;
+  debug('pskRole: %s', this.role);
+
+  this.stripTrailingSlash();
+
+  // Role data lookup on ACL.
+  var roleIndex = fast.indexOf(this.acl, this.role, 'role');
+  if (roleIndex === -1) {
+    return this.unauthorized(1);
+  }
+  var paths = this.acl[roleIndex].paths;
+
+  // Path data lookup on paths.
+  var pathIndex = fast.indexOf(paths, this.path, 'path');
+  if (pathIndex !== -1) {
+    var verbs = paths[pathIndex].verbs;
+
+    // Request method lookup on verbs.
+    var verbIndex = fast.indexOf(verbs, this.request.method);
+    if (verbIndex !== -1) {
+      return this.authorized('found rawpath');
+    } else {
+      return this.unauthorized(2);
+    }
+  }
+
+  // This section deals with /db/id, /db/_local/id and /db/id/attachment stuff.
+  if (!this.cutDBPrefix()) {
+    return this.unauthorized(3);
+  }
+
+  var pathParts = this.path.split('/');
+  if (pathParts[0] !== '') {
+    // Sanity check, the first element should always be empty.
+    return this.unauthorized(4);
+  }
+
+  return this.unauthorized(5);
 }
 
-// Gets the req object, collection of paths, and path to validate
-function lookupPathVerb(req, paths, path, lookupPath) {
-  var pathExists = fast.indexOf(paths, lookupPath, 'path');
+Filter.prototype.stripTrailingSlash = function () {
+  if (this.options.stripTrailingSlash) {
+    // Single slash '/' is a valid path, it should be ignored.
+    var lastIndex = this.path.length - 1;
+    if (lastIndex > 0 && this.path[lastIndex] === '/') {
+      debug('ignoring trailing slash for %s', this.path);
+      this.path = this.path.substring(0, lastIndex);
+    }
+  }
+}
 
-  if (NOTFOUND === pathExists) {
+Filter.prototype.cutDBPrefix = function () {
+  var isDbPath = this.path.startsWith(this.dbPrefix);
+  if (!isDbPath) {
     return false;
   }
-  // verbs are just an array of strings
-  var verbs = paths[pathExists].verbs;
-  var verbExists = fast.indexOf(verbs, req.method);
-
-  if (NOTFOUND === verbExists) {
-    debug(
-      'verb and path not found: req.Path: %s  lookupPath: %s',
-      path, lookupPath
-    );
-    return false;
-  }
-
+  this.path = this.path.substring(this.dbPrefix.length);
   return true;
 }
 
-// given the path it determines the ID and calls the callback with that ID
-function getThaliId(req, path, dbname, callback) {
-  var matches = path.match('^(\/' + dbname + '\/_local\/thali_)(.+)');
-  if (matches && matches.length === 3) {
-    return callback(matches[2], req);
-  }
-  return false;
+Filter.prototype.authorized = function () {
+  debug.apply(debug, arguments);
+  this.nextHandler();
+  return;
 }
 
-if (!String.prototype.startsWith) {
-  String.prototype.startsWith = function (searchString, position){
-    position = position || 0;
-    return this.substr(position, searchString.length) === searchString;
-  };
-}
-
-
-
-module.exports = function (dbname, inAcl, callback, options) {
-
-  if (!dbname || typeof dbname !== 'string') {
-    throw new Error('invalid configuration - missing dbname');
-  }
-
-  if (!inAcl || !(inAcl instanceof Array)) {
-    throw new Error('invalid configuration - inAcl is not an array');
-  }
-
-  if (!callback || typeof callback !== 'function') {
-    throw new Error('invalid configuration - callback is NOT a function');
-  }
-
-  options = objectAssign({}, defaults, options);
-
-  var thaliPrefix = '/' + dbname + '/_local/thali_';
-
-  var acl = JSON.parse(JSON.stringify(inAcl).replace(/{:db}/g, dbname));
-
-  // path.role.verb
-  var msg401 = { success: false, message: 'Unauthorized' };
-
-  return function (req, res, next) {
-    var okPathVerb = false;
-    debug('method: %s url: %s path: %s', req.method, req.url, req.path);
-
-    var path = req.path;
-    if (req.connection.prefix) {
-      path = stripPrefix(path, req.connection.prefix);
-      if (!path) {
-        debug('unauthorized0: no prefix: %s ', req.path);
-        return res.status(401).send(msg401);
-      }
-    }
-    if (options.stripTrailingSlash) {
-      path = stripTrailingSlash(path);
-    }
-
-    if (!req.connection.pskRole) {
-      debug('unauthorized0: no role: %s ', path);
-      return res.status(401).send(msg401);
-    }
-
-    var pskRole = req.connection.pskRole;
-    debug('pskRole: %s', pskRole);
-
-    var roleExists = fast.indexOf(acl, pskRole, 'role');
-
-    if (NOTFOUND === roleExists) {
-      debug('unauthorized1: %s : %s', pskRole, path);
-      return res.status(401).send(msg401);
-    }
-
-    var paths = acl[roleExists].paths;
-
-    // here we're doing a strict simple RAW path lookup on ACLs
-    var rawExists = fast.indexOf(paths, path, 'path');
-
-    if (NOTFOUND !== rawExists) {
-      // verbs are just an array of strings
-      var verbs = paths[rawExists].verbs;
-      var verbExists = fast.indexOf(verbs, req.method);
-
-      if (NOTFOUND === verbExists) {
-        debug('unauthorized3: %s : %s', pskRole, path);
-        return res.status(401).send(msg401);
-      }
-      else {
-        debug('found rawpath');
-        okPathVerb = true;
-      }
-    }
-
-    else {
-      // this section deals with /db/id, /db/_local/id,
-      // and /db/id/attachment stuff.
-      var pathParts = path.split('/');
-
-      if (pathParts[0] !== '') {
-        // sanity check.. the first element should always be empty.
-        debug('unauthorized4.0: %s : %s', pskRole, path);
-        return res.status(401).send(msg401);
-      }
-
-      var lookupPath = path.substring(0, path.lastIndexOf('/') + 1) + IDTOKEN;
-
-      if (pathParts.length === 3) {
-        // we have just a path and ID
-        // do a search on /db/id and bail if NO GOOD
-        if (!lookupPathVerb(req, paths, path, lookupPath)) {
-          debug(
-            'unauthorized4.1: req.Path: %s  req.path: %s',
-            path, lookupPath
-          );
-          return res.status(401).send(msg401);
-        }
-        else {
-          debug('found path and id');
-          okPathVerb = true;
-        }
-      }
-      else if (pathParts.length === 4 && pathParts[2] === '_local') {
-        // is this a /thali_ one?
-
-        // TODO:
-        var isThaliPrefix = path.startsWith(thaliPrefix);
-        if (
-          isThaliPrefix &&
-          !lookupPathVerb(req, paths, path, thaliPrefix + IDTOKEN)
-        ) {
-          debug(
-            'unauthorized4.thaliPrefix: req.Path: %s  path: %s',
-            path, thaliPrefix
-          );
-          return res.status(401).send(msg401);
-        }
-
-        if (isThaliPrefix && !getThaliId(req, path, dbname, callback)) {
-          debug(
-            'unauthorized4.thaliCallback: req.Path: %s  path: %s',
-            path, thaliPrefix
-          );
-          return res.status(401).send(msg401);
-        }
-
-        if (!lookupPathVerb(req, paths, path, lookupPath)) {
-          debug(
-            'unauthorized4.2: req.Path: %s  req.path: %s',
-            path, lookupPath
-          );
-          return res.status(401).send(msg401);
-        }
-        else {
-          debug('passed _local and thali checks.');
-          okPathVerb = true;
-        }
-      }
-      else if (pathParts.length === 4 && pathParts[3] === 'attachment') {
-        var attachmentPath = '/' + pathParts[1] + '/' + IDTOKEN + '/attachment';
-
-        if (!lookupPathVerb(req, paths, path, attachmentPath)) {
-          debug(
-            'unauthorized4.3: req.Path: %s  req.path: %s',
-            path, attachmentPath
-          );
-          return res.status(401).send(msg401);
-        }
-        else {
-          okPathVerb = true;
-        }
-      }
-      else {
-        debug('unauthorized5: %s : %s', pskRole, path);
-        return res.status(401).send(msg401);
-      }
-    }
-
-    // might want to check if isvalid true too.
-    // All good - next in pipeline
-    debug('outside all ifs okPathVerb: %s', okPathVerb);
-
-    assert.ok(okPathVerb);
-    next();
-
-  };
+Filter.message401 = {
+  success: false,
+  message: 'Unauthorized'
 };
+
+Filter.prototype.unauthorized = function (index) {
+  debug('unauthorized %s: pskRole: %s, path: %s, verb: %s', index, this.role, this.path, this.request.method);
+  return this.response.status(401).send(Filter.message401);
+}
+
+module.exports = Filter;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,7 @@ var NOTFOUND = -1;
 var IDTOKEN = '{:id}';
 
 var defaults = {
-  stripTrailingSlash: true,
-  prefix: undefined
+  stripTrailingSlash: true
 };
 
 function stripPrefix(path, prefix) {
@@ -100,8 +99,8 @@ module.exports = function (dbname, inAcl, callback, options) {
     debug('method: %s url: %s path: %s', req.method, req.url, req.path);
 
     var path = req.path;
-    if (options.prefix) {
-      path = stripPrefix(path, options.prefix);
+    if (req.connection.prefix) {
+      path = stripPrefix(path, req.connection.prefix);
       if (!path) {
         debug('unauthorized0: no prefix: %s ', req.path);
         return res.status(401).send(msg401);

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,8 @@ Salti.prototype.init = function () {
   if (this.options.dbPrefix) {
     // DB prefix in options can include leading slash.
     // We should strip it for DB path.
-    this.dbPath = Salti.stripLeadingSlash(this.options.dbPrefix) + '/' + this.dbPath;
+    this.dbPath = Salti.stripLeadingSlash(this.options.dbPrefix) + '/' +
+      this.dbPath;
   }
   this.dbPrefix = '/' + this.dbPath;
 
@@ -74,14 +75,17 @@ Salti.prototype.init = function () {
       });
     }
   });
-}
+};
 
 Salti.prototype.handler = function (request, response, nextHandler) {
   this.request = request;
   this.response = response;
   this.nextHandler = nextHandler;
   this.path = request.path;
-  debug('method: %s, url: %s, path: %s', this.request.method, this.request.url, this.path);
+  debug(
+    'method: %s, url: %s, path: %s',
+    this.request.method, this.request.url, this.path
+  );
 
   if (!this.request.connection.pskRole) {
     return this.unauthorized(0);
@@ -109,7 +113,8 @@ Salti.prototype.handler = function (request, response, nextHandler) {
     return this.unauthorized(2);
   }
 
-  // Next section deals with /{:db}/{:id}, /{:db}/_local/{:id} and /{:db}/{:id}/attachment stuff.
+  // Next section deals with
+  // /{:db}/{:id}, /{:db}/_local/{:id} and /{:db}/{:id}/attachment stuff.
   if (!this.cutDBPrefix()) {
     // Required DB Prefix is not valid.
     return this.unauthorized(3);
@@ -132,13 +137,14 @@ Salti.prototype.handler = function (request, response, nextHandler) {
       return this.unauthorized(5);
     }
   }
-  
+
   else if (pathParts.length === 3 && pathParts[1] === '_local') {
     // Is this a thali {:id}?
     var isThaliPrefix = this.path.startsWith(Salti.thaliPrefix);
     if (isThaliPrefix) {
       // Is /_local/thali_{:id} authorized?
-      lookupPath = this.dbPrefix + Salti.thaliPrefix + this.options.idTokenTemplate;
+      lookupPath = this.dbPrefix + Salti.thaliPrefix +
+        this.options.idTokenTemplate;
       if (this.lookupPathVerb(paths, lookupPath) !== Salti.PATH_VERB_FOUND) {
         debug('unauthorized thali prefix');
         return this.unauthorized(6);
@@ -150,7 +156,7 @@ Salti.prototype.handler = function (request, response, nextHandler) {
       }
       debug('passed _thali check');
     }
-    
+
     // Is /_local/{:id} authorized?
     lookupPath = this.dbPrefix + '/_local/' + this.options.idTokenTemplate;
     if (this.lookupPathVerb(paths, lookupPath) === Salti.PATH_VERB_FOUND) {
@@ -159,10 +165,11 @@ Salti.prototype.handler = function (request, response, nextHandler) {
       return this.unauthorized(8);
     }
   }
-  
+
   else if (pathParts.length === 3 && pathParts[2] === 'attachment') {
     // Is /{:id}/attachment authorized?
-    lookupPath = this.dbPrefix + '/' + this.options.idTokenTemplate + '/attachment';
+    lookupPath = this.dbPrefix + '/' + this.options.idTokenTemplate +
+      '/attachment';
     if (this.lookupPathVerb(paths, lookupPath) === Salti.PATH_VERB_FOUND) {
       return this.authorized('passed attachment check');
     } else {
@@ -171,7 +178,7 @@ Salti.prototype.handler = function (request, response, nextHandler) {
   }
 
   return this.unauthorized(10);
-}
+};
 
 Salti.PATH_VERB_FOUND = 0;
 Salti.PATH_NOTFOUND = 1;
@@ -187,18 +194,21 @@ Salti.prototype.lookupPathVerb = function (paths, lookupPath) {
   var verbs = paths[pathIndex].verbs;
   var verbIndex = fast.indexOf(verbs, this.request.method);
   if (verbIndex === -1) {
-    debug('verb and path are not found: lookupPath: %s, verb: %s', lookupPath, this.request.method);
+    debug(
+      'verb and path are not found: lookupPath: %s, verb: %s',
+      lookupPath, this.request.method
+    );
     return Salti.VERB_NOTFOUND;
   }
   return Salti.PATH_VERB_FOUND;
-}
+};
 
 Salti.prototype.resolveThaliId = function (thaliId) {
   if (thaliId.length > 0) {
     return this.thaliIdCallback(thaliId, this.request);
   }
   return false;
-}
+};
 
 Salti.stripLeadingSlash = function (path) {
   if (path.length > 0 && path[0] === '/') {
@@ -206,7 +216,7 @@ Salti.stripLeadingSlash = function (path) {
     return path.substring(1);
   }
   return path;
-}
+};
 Salti.stripTrailingSlash = function (path) {
   // Single slash '/' is a valid path.
   // It's slash is leading, not trailing.
@@ -217,7 +227,7 @@ Salti.stripTrailingSlash = function (path) {
     return path.substring(0, lastIndex);
   }
   return path;
-}
+};
 
 Salti.prototype.cutDBPrefix = function () {
   var isDbPath = this.path.startsWith(this.dbPrefix);
@@ -226,13 +236,13 @@ Salti.prototype.cutDBPrefix = function () {
   }
   this.path = this.path.substring(this.dbPrefix.length);
   return true;
-}
+};
 
 Salti.prototype.authorized = function () {
   debug.apply(debug, arguments);
   this.nextHandler();
   return;
-}
+};
 
 Salti.message401 = {
   success: false,
@@ -240,8 +250,11 @@ Salti.message401 = {
 };
 
 Salti.prototype.unauthorized = function (index) {
-  debug('unauthorized %s: pskRole: %s, path: %s, verb: %s', index, this.role, this.path, this.request.method);
+  debug(
+    'unauthorized %s: pskRole: %s, path: %s, verb: %s',
+    index, this.role, this.path, this.request.method
+  );
   return this.response.status(401).send(Salti.message401);
-}
+};
 
 module.exports = Salti;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,12 +14,12 @@ var defaults = {
   prefix: undefined
 };
 
-
 function stripPrefix(path, prefix) {
+  // prefix is required
   if (path.indexOf(prefix) === 0) {
     return path.substring(prefix.length);
   }
-  return path;
+  return undefined;
 }
 
 function stripTrailingSlash(path) {
@@ -32,26 +32,29 @@ function stripTrailingSlash(path) {
   return path;
 }
 
-/** Gets the req object, collection of paths, and path to validate */
+// Gets the req object, collection of paths, and path to validate
 function lookupPathVerb(req, paths, path, lookupPath) {
   var pathExists = fast.indexOf(paths, lookupPath, 'path');
 
   if (NOTFOUND === pathExists) {
     return false;
   }
-  //verbs are just an array of strings
+  // verbs are just an array of strings
   var verbs = paths[pathExists].verbs;
   var verbExists = fast.indexOf(verbs, req.method);
 
   if (NOTFOUND === verbExists) {
-    debug('verb and path not found: req.Path: %s  lookupPath: %s', path, lookupPath);
+    debug(
+      'verb and path not found: req.Path: %s  lookupPath: %s',
+      path, lookupPath
+    );
     return false;
   }
 
   return true;
 }
 
-/** given the path it determines the ID and calls the callback with that ID */
+// given the path it determines the ID and calls the callback with that ID
 function getThaliId(req, path, dbname, callback) {
   var matches = path.match('^(\/' + dbname + '\/_local\/thali_)(.+)');
   if (matches && matches.length === 3) {
@@ -61,15 +64,15 @@ function getThaliId(req, path, dbname, callback) {
 }
 
 if (!String.prototype.startsWith) {
-    String.prototype.startsWith = function(searchString, position){
-      position = position || 0;
-      return this.substr(position, searchString.length) === searchString;
+  String.prototype.startsWith = function (searchString, position){
+    position = position || 0;
+    return this.substr(position, searchString.length) === searchString;
   };
 }
 
 
 
-module.exports = function(dbname, inAcl, callback, options) {
+module.exports = function (dbname, inAcl, callback, options) {
 
   if (!dbname || typeof dbname !== 'string') {
     throw new Error('invalid configuration - missing dbname');
@@ -79,7 +82,7 @@ module.exports = function(dbname, inAcl, callback, options) {
     throw new Error('invalid configuration - inAcl is not an array');
   }
 
-  if(!callback || typeof callback !== 'function'){
+  if (!callback || typeof callback !== 'function') {
     throw new Error('invalid configuration - callback is NOT a function');
   }
 
@@ -89,16 +92,19 @@ module.exports = function(dbname, inAcl, callback, options) {
 
   var acl = JSON.parse(JSON.stringify(inAcl).replace(/{:db}/g, dbname));
 
-  //path.role.verb
+  // path.role.verb
   var msg401 = { success: false, message: 'Unauthorized' };
 
-  return function(req, res, next) {
+  return function (req, res, next) {
     var okPathVerb = false;
     debug('method: %s url: %s path: %s', req.method, req.url, req.path);
 
     var path = req.path;
     if (options.prefix) {
       path = stripPrefix(path, options.prefix);
+      if (!path) {
+        return res.status(401).send(msg401);
+      }
     }
     if (options.stripTrailingSlash) {
       path = stripTrailingSlash(path);
@@ -121,11 +127,11 @@ module.exports = function(dbname, inAcl, callback, options) {
 
     var paths = acl[roleExists].paths;
 
-    //here we're doing a strict simple RAW path lookup on ACLs
+    // here we're doing a strict simple RAW path lookup on ACLs
     var rawExists = fast.indexOf(paths, path, 'path');
 
     if (NOTFOUND !== rawExists) {
-      //verbs are just an array of strings
+      // verbs are just an array of strings
       var verbs = paths[rawExists].verbs;
       var verbExists = fast.indexOf(verbs, req.method);
 
@@ -140,11 +146,12 @@ module.exports = function(dbname, inAcl, callback, options) {
     }
 
     else {
-      //this section deals with /db/id, /db/_local/id, and /db/id/attachment stuff.
+      // this section deals with /db/id, /db/_local/id,
+      // and /db/id/attachment stuff.
       var pathParts = path.split('/');
 
       if (pathParts[0] !== '') {
-        //sanity check.. the first element should always be empty.
+        // sanity check.. the first element should always be empty.
         debug('unauthorized4.0: %s : %s', pskRole, path);
         return res.status(401).send(msg401);
       }
@@ -152,10 +159,13 @@ module.exports = function(dbname, inAcl, callback, options) {
       var lookupPath = path.substring(0, path.lastIndexOf('/') + 1) + IDTOKEN;
 
       if (pathParts.length === 3) {
-        //we have just a path and ID
-        //do a search on /db/id and bail if NO GOOD
+        // we have just a path and ID
+        // do a search on /db/id and bail if NO GOOD
         if (!lookupPathVerb(req, paths, path, lookupPath)) {
-          debug('unauthorized4.1: req.Path: %s  req.path: %s', path, lookupPath);
+          debug(
+            'unauthorized4.1: req.Path: %s  req.path: %s',
+            path, lookupPath
+          );
           return res.status(401).send(msg401);
         }
         else {
@@ -164,22 +174,34 @@ module.exports = function(dbname, inAcl, callback, options) {
         }
       }
       else if (pathParts.length === 4 && pathParts[2] === '_local') {
-        //is this a /thali_ one?
+        // is this a /thali_ one?
 
-        //TODO:
+        // TODO:
         var isThaliPrefix = path.startsWith(thaliPrefix);
-        if (isThaliPrefix && ! lookupPathVerb(req, paths, path, thaliPrefix + IDTOKEN)){
-          debug('unauthorized4.thaliPrefix: req.Path: %s  path: %s', path, thaliPrefix);
+        if (
+          isThaliPrefix &&
+          !lookupPathVerb(req, paths, path, thaliPrefix + IDTOKEN)
+        ) {
+          debug(
+            'unauthorized4.thaliPrefix: req.Path: %s  path: %s',
+            path, thaliPrefix
+          );
           return res.status(401).send(msg401);
         }
 
         if (isThaliPrefix && !getThaliId(req, path, dbname, callback)) {
-          debug('unauthorized4.thaliCallback: req.Path: %s  path: %s', path, thaliPrefix);
+          debug(
+            'unauthorized4.thaliCallback: req.Path: %s  path: %s',
+            path, thaliPrefix
+          );
           return res.status(401).send(msg401);
         }
 
         if (!lookupPathVerb(req, paths, path, lookupPath)) {
-          debug('unauthorized4.2: req.Path: %s  req.path: %s', path, lookupPath);
+          debug(
+            'unauthorized4.2: req.Path: %s  req.path: %s',
+            path, lookupPath
+          );
           return res.status(401).send(msg401);
         }
         else {
@@ -191,7 +213,10 @@ module.exports = function(dbname, inAcl, callback, options) {
         var attachmentPath = '/' + pathParts[1] + '/' + IDTOKEN + '/attachment';
 
         if (!lookupPathVerb(req, paths, path, attachmentPath)) {
-          debug('unauthorized4.3: req.Path: %s  req.path: %s', path, attachmentPath);
+          debug(
+            'unauthorized4.3: req.Path: %s  req.path: %s',
+            path, attachmentPath
+          );
           return res.status(401).send(msg401);
         }
         else {
@@ -204,8 +229,8 @@ module.exports = function(dbname, inAcl, callback, options) {
       }
     }
 
-    //might want to check if isvalid true too.
-    //All good - next in pipeline
+    // might want to check if isvalid true too.
+    // All good - next in pipeline
     debug('outside all ifs okPathVerb: %s', okPathVerb);
 
     assert.ok(okPathVerb);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "homepage": "https://github.com/thaliproject/salti#readme",
   "dependencies": {
     "object-assign": "^4.1.0",
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "jsonschema": "^1.1.0"
   },
   "devDependencies": {
     "colors": "^1.1.2",

--- a/test/acl-block.1.js
+++ b/test/acl-block.1.js
@@ -1,39 +1,47 @@
 'use strict';
 
-//role.path.verb
-
-
-module.exports =  [{
-  'role' : 'repl',
-  'paths' : [
-    {'path':'/',
-    'verbs': ['GET']
-  },{'path': '/{:db}',
-    'verbs' :['GET']
-  },{
-    'path' : '/{:db}/_all_docs',
-    'verbs':['GET', 'HEAD', 'POST']
-  },{
-    'path' :'/{:db}/_changes',
-    'verbs':['GET', 'POST']
-  },{
-    'path' :'/{:db}/_bulk_get',
-    'verbs': ['POST']
-  }, {
-    'path' :'/{:db}/_revs_diff',
-    'verbs':['POST']
-  }, {
-    'path' :'/{:db}/{:id}',
-    'verbs' :['GET']
-  }, {
-    'path' :'/{:db}/{:id}/attachment',
-    'verbs':['GET']
-  }, {
-    'path' :'/{:db}/_local/{:id}',
-    'verbs':['GET', 'PUT', 'DELETE']
-  }, {
-    'path': '/{:db}/_local/thali_{:id}',
-    'verbs':['GET', 'PUT', 'DELETE']
-  }
+module.exports = [{
+  'role': 'repl',
+  'paths': [
+    {
+      'path': '/',
+      'verbs': ['GET']
+    },
+    {
+      'path': '/{:db}',
+      'verbs': ['GET']
+    },
+    {
+      'path': '/{:db}/_all_docs',
+      'verbs': ['GET', 'HEAD', 'POST']
+    },
+    {
+      'path': '/{:db}/_changes',
+      'verbs': ['GET', 'POST']
+    },
+    {
+      'path': '/{:db}/_bulk_get',
+      'verbs': ['POST']
+    },
+    {
+      'path': '/{:db}/_revs_diff',
+      'verbs': ['POST']
+    },
+    {
+      'path': '/{:db}/{:id}',
+      'verbs': ['GET']
+    },
+    {
+      'path': '/{:db}/{:id}/attachment',
+      'verbs': ['GET']
+    },
+    {
+      'path': '/{:db}/_local/{:id}',
+      'verbs': ['GET', 'PUT', 'DELETE']
+    },
+    {
+      'path': '/{:db}/_local/thali_{:id}',
+      'verbs': ['GET', 'PUT', 'DELETE']
+    }
   ]
 }];

--- a/test/handlers2.js
+++ b/test/handlers2.js
@@ -3,34 +3,34 @@
 var colors = require('colors');
 
 module.exports = {
-  get: function(req, res) {
+  get: function (req, res) {
     console.log(colors.green('\tin the handler for get'));
     res.status(200).json({ message: 'you made it' });
     // next();
   },
-  post: function(req, res) {
+  post: function (req, res) {
     console.log(colors.green('\tin the post handler'));
     res.status(200).json({ name: 'you made it' });
     // next();
   },
-  put: function(req, res) {
+  put: function (req, res) {
     console.log(colors.green('\tin the put handler'));
     res.status(200).json({ name: 'you made it' });
     // next();
   },
-  head: function(req, res) {
+  head: function (req, res) {
     console.log(colors.green('\tin the head handler'));
     res.status(200);//.json({ name: 'you made it' });
     // next();
   },
-  options: function(req, res) {
+  options: function (req, res) {
     console.log(colors.green('\tin the options handler'));
     res.status(200).json({ name: 'you made it' });
     // next();
   },
-  delete: function(req, res) {
+  delete: function (req, res) {
     console.log(colors.green('\tin the delete handler'));
     res.status(200).json({ name: 'you made it' });
     // next();
   }
-}
+};

--- a/test/jshint.spec.js
+++ b/test/jshint.spec.js
@@ -1,5 +1,5 @@
 require('mocha-jshint')({
-	paths: [
-		'./lib/'
-	]
+  paths: [
+    './lib/'
+  ]
 });

--- a/test/test-core-alldocs.js
+++ b/test/test-core-alldocs.js
@@ -5,18 +5,19 @@
     ** | /:db/_all_docs         | GET, HEAD, POST [1]     | allDocs |
 */
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var lib = require(path.join(__dirname, '../lib/index'));
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
+var acl = require('./acl-block.1.js');
+
 var dbName = 'foobar';
 var path = '/' + dbName + '/_all_docs';
 
 function genericHandlers(router, path) {
-  var handlers = require('./handlers2');
   router.get(path, handlers.get);
   router.post(path, handlers.post);
   router.put(path, handlers.put);
@@ -25,52 +26,52 @@ function genericHandlers(router, path) {
   return router;
 }
 
-describe('test-core-db-2.js - calling the /db path', function() {
-  describe('using repl identity', function() {
-    var app, router; app = express(); router = express.Router();
+describe('test-core-db-2.js - calling the /db path', function () {
+  describe('using repl identity', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
+    before(function () {
+      // mocker..
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'repl';
         next();
-      })
-      //Norml middleware usage..0
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, function(){}));
-      //mock handlers
+      });
+      // Norml middleware usage..0
+      router.all('*', lib('foobar', acl, function (){}));
+      // mock handlers
       app.use('/', genericHandlers(router, path));
-    })
+    });
 
-    it('GET should be 200', function(done) {
+    it('GET should be 200', function (done) {
       request(app)
         .get(path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    it('PUT should be 401', function(done) {
+    });
+    it('PUT should be 401', function (done) {
       request(app)
         .put(path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('POST should be 200', function(done) {
+    });
+    it('POST should be 200', function (done) {
       request(app)
         .post(path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    it('HEAD should be 200', function(done) {
+    });
+    it('HEAD should be 200', function (done) {
       request(app)
         .head(path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    it('OPTION should be 401', function(done) {
+    });
+    it('OPTION should be 401', function (done) {
       request(app)
         .options(path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-  })
-})
+    });
+  });
+});

--- a/test/test-core-alldocs.js
+++ b/test/test-core-alldocs.js
@@ -7,11 +7,11 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var path = '/' + dbName + '/_all_docs';
 

--- a/test/test-core-attachment.js
+++ b/test/test-core-attachment.js
@@ -5,81 +5,82 @@
     ** | /:db/:id/attachment        | GET,     | |
 */
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var lib = require(path.join(__dirname, '../lib/index'));
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
+var acl = require('./acl-block.1.js');
+
 var dbName = 'foobar';
 var path = '/' + dbName + '/1234/attachment';
 
 function genericHandlers(router, path) {
-  var handlers = require('./handlers2');
   router.get(path, handlers.get);
   return router;
 }
 
-describe('test-core-attachment.js - calling the /db/id/attachment path', function() {
-  describe('using repl identity', function() {
-    var app, router; app = express(); router = express.Router();
+describe(
+  'test-core-attachment.js - calling the /db/id/attachment path', function () {
+  describe('using repl identity', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
+    before(function () {
+      // mocker..
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'repl';
         next();
-      })
-      //Norml middleware usage..0
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, function(){}));
-      //mock handlers  
+      });
+      // Norml middleware usage..0
+      router.all('*', lib('foobar', acl, function (){}));
+      // mock handlers
       app.use('/', genericHandlers(router, path));
-    })
+    });
 
-    it('GET should be 200', function(done) {
+    it('GET should be 200', function (done) {
       request(app)
         .get(path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    
-    it('POST should be 401', function(done) {
+    });
+
+    it('POST should be 401', function (done) {
       request(app)
         .post(path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    
-    it('PUT should be 401', function(done) {
+    });
+
+    it('PUT should be 401', function (done) {
       request(app)
         .put(path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    
-    
-    it('GET /zzz should be 401', function(done) {
+    });
+
+
+    it('GET /zzz should be 401', function (done) {
       request(app)
         .get(path + '/zzz')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    
-    it('GET /zzz/ should be 401', function(done) {
+    });
+
+    it('GET /zzz/ should be 401', function (done) {
       request(app)
         .get(path + '/zzz/')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    
-    it('GET zzz should be 401', function(done) {
+    });
+
+    it('GET zzz should be 401', function (done) {
       request(app)
         .get(path + 'zzz')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    
-  })
-})
+    });
+  });
+});

--- a/test/test-core-attachment.js
+++ b/test/test-core-attachment.js
@@ -7,11 +7,11 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var path = '/' + dbName + '/1234/attachment';
 

--- a/test/test-core-bulkget.js
+++ b/test/test-core-bulkget.js
@@ -6,11 +6,11 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var path = '/' + dbName + '/_bulk_get';
 

--- a/test/test-core-bulkget.js
+++ b/test/test-core-bulkget.js
@@ -1,60 +1,61 @@
+'use strict';
 
 /**
  *   * | /:db/_bulk_get              | GET                     | get |
  */
 
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
+var acl = require('./acl-block.1.js');
 
-var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var path = '/' + dbName + '/_bulk_get';
 
 function genericHandlers(router, path) {
-  var handlers = require('./handlers2');
   router.post(path, handlers.get);
   return router;
 }
 
-describe('test-core-bulk-get - calling the /db/id path', function() {
-  describe('using repl identity', function() {
-    var app, router; app = express(); router = express.Router();
+describe('test-core-bulk-get - calling the /db/id path', function () {
+  describe('using repl identity', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
+    before(function () {
+      // mocker..
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'repl';
         next();
-      })
-      //Norml middleware usage..0
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, function(){}));
-      //mock handlers  
+      });
+      // Norml middleware usage..0
+      router.all('*', lib('foobar', acl, function (){}));
+      // mock handlers
       app.use('/', genericHandlers(router, path));
-    })
+    });
 
-    it('POST should be 200', function(done) {
+    it('POST should be 200', function (done) {
       request(app)
         .post(path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-   
-    it('GET should be 401', function(done) {
+    });
+
+    it('GET should be 401', function (done) {
       request(app)
         .get(path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('GET should be 401 added path', function(done) {
+    });
+    it('GET should be 401 added path', function (done) {
       request(app)
         .get(path + '/1234/1234')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-  })
-})
+    });
+  });
+});

--- a/test/test-core-db.js
+++ b/test/test-core-db.js
@@ -2,19 +2,19 @@
 
 /** this will check the following:
   ** DB spedific paths - note that ':db' token to be substituted with the db name in that context
-     * | /:db                   | GET                     | info |     
+     * | /:db                   | GET                     | info |
 */
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var lib = require(path.join(__dirname, '../lib/index'));
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
+var acl = require('./acl-block.1.js');
 
 function genericHandlers(router, dbname) {
-  var handlers = require('./handlers2');
   router.get('/' + dbname, handlers.get);
   router.post('/' + dbname, handlers.post);
   router.put('/' + dbname, handlers.put);
@@ -23,105 +23,103 @@ function genericHandlers(router, dbname) {
   return router;
 }
 
-describe('test-core-db.js - calling the /db path', function() {
-  describe('using repl identity', function() {
-    var app, router; app = express(); router = express.Router();
+describe('test-core-db.js - calling the /db path', function () {
+  describe('using repl identity', function () {
+    var app = express();
+    var router = express.Router();
     var dbName = 'foobar';
 
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
+    before(function () {
+      // mocker..
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'repl';
         next();
-      })
-      //Norml middleware usage..
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl,  function(){}));
-      //mock handlers  
+      });
+      // Norml middleware usage..
+      router.all('*', lib('foobar', acl,  function (){}));
+      // mock handlers
       app.use('/', genericHandlers(router, dbName));
-    })
+    });
 
-    it('GET should be 200', function(done) {
+    it('GET should be 200', function (done) {
       request(app)
         .get('/' + dbName)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    it('PUT should be 401', function(done) {
+    });
+    it('PUT should be 401', function (done) {
       request(app)
         .put('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('POST should be 401', function(done) {
+    });
+    it('POST should be 401', function (done) {
       request(app)
         .post('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('HEAD should be 401', function(done) {
+    });
+    it('HEAD should be 401', function (done) {
       request(app)
         .head('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('OPTION should be 401', function(done) {
+    });
+    it('OPTION should be 401', function (done) {
       request(app)
         .options('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
+    });
+  });
+});
 
-  })
-})
-
-
-describe('test-core-db.js - calling the /WRONG db path', function() {
-  describe('using repl identity', function() {
-    var app, router; app = express(); router = express.Router();
+describe('test-core-db.js - calling the /WRONG db path', function () {
+  describe('using repl identity', function () {
+    var app = express();
+    var router = express.Router();
     var dbName = 'foobarbad';
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
+
+    before(function () {
+      // mocker..
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'repl';
         next();
-      })
-      //Norml middleware usage..
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, function(){}));
-      //mock handlers  
+      });
+      // Norml middleware usage..
+      router.all('*', lib('foobar', acl, function (){}));
+      // mock handlers
       app.use('/', genericHandlers(router, dbName));
-    })
-    it('GET should be 401', function(done) {
+    });
+    it('GET should be 401', function (done) {
       request(app)
         .get('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('PUT should be 401', function(done) {
+    });
+    it('PUT should be 401', function (done) {
       request(app)
         .put('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('POST should be 401', function(done) {
+    });
+    it('POST should be 401', function (done) {
       request(app)
         .post('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('HEAD should be 401', function(done) {
+    });
+    it('HEAD should be 401', function (done) {
       request(app)
         .head('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('OPTION should be 401', function(done) {
+    });
+    it('OPTION should be 401', function (done) {
       request(app)
         .options('/' + dbName)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-
-  })
-})
+    });
+  });
+});

--- a/test/test-core-resources-local.js
+++ b/test/test-core-resources-local.js
@@ -1,90 +1,88 @@
+'use strict';
 
 /**
      * | /:db/_local/:id  | GET, PUT, DELETE        | get, put, remove |
  */
 
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var lib = require(path.join(__dirname, '../lib/index'));
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
+var acl = require('./acl-block.1.js');
+
 var dbName = 'foobar';
 var path = dbName + '/_local/1234';
 
 function genericHandlers(router, path) {
-  var handlers = require('./handlers2');
-  router.get('/' + path, handlers.get); 
+  router.get('/' + path, handlers.get);
   router.put('/' + path, handlers.put);
   router.delete('/' + path, handlers.delete);
   return router;
 }
 
-describe('test-core- LOCAL - calling the /db/_local/{id} path', function() {
-  describe('using repl identity', function() {
-    var app, router; app = express(); router = express.Router();
+describe('test-core- LOCAL - calling the /db/_local/{id} path', function () {
+  describe('using repl identity', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
+    before(function () {
+      // mocker..
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'repl';
         next();
-      })
-      //Norml middleware usage..0
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, function(){}));
-      //mock handlers  
+      });
+      // Norml middleware usage..0
+      router.all('*', lib('foobar', acl, function (){}));
+      // mock handlers
       app.use('/', genericHandlers(router, path));
-    })
+    });
 
-    it('GET should be 200 ' + '/' + path, function(done) {
+    it('GET should be 200 ' + '/' + path, function (done) {
       request(app)
         .get('/' + path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    it('PUT should be 200', function(done) {
+    });
+    it('PUT should be 200', function (done) {
       request(app)
         .put('/' + path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    it('DELETE should be 200', function(done) {
+    });
+    it('DELETE should be 200', function (done) {
       request(app)
         .delete('/' + path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    it('POST should be 401', function(done) {
+    });
+    it('POST should be 401', function (done) {
       request(app)
         .post('/' + path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
+    });
 
-    it('GET should be 401 on /1234/1234', function(done) {
+    it('GET should be 401 on /1234/1234', function (done) {
       request(app)
         .get('/' + path + '/1234')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('PUT should be 401', function(done) {
+    });
+    it('PUT should be 401', function (done) {
       request(app)
         .put('/' + path + '/1234')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('DELETE should be 401', function(done) {
+    });
+    it('DELETE should be 401', function (done) {
       request(app)
         .delete('/' + path + '/1234')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-
-
-
-
-  })
-})
+    });
+  });
+});

--- a/test/test-core-resources-local.js
+++ b/test/test-core-resources-local.js
@@ -6,11 +6,11 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var path = dbName + '/_local/1234';
 

--- a/test/test-core-resources.js
+++ b/test/test-core-resources.js
@@ -6,11 +6,11 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var path = dbName + '/1234';
 

--- a/test/test-core-resources.js
+++ b/test/test-core-resources.js
@@ -1,111 +1,111 @@
+'use strict';
 
 /**
      * | /:db/:id  | GET, PUT, DELETE        | get, put, remove |
  */
 
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
+var acl = require('./acl-block.1.js');
 
-var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var path = dbName + '/1234';
 
-function genericHandlers(router, path) {
-  var handlers = require('./handlers2');
-  router.get('/' + dbName + '/1234', handlers.get);
+function genericHandlers(router) {
+  router.get('/' + path, handlers.get);
   router.get('/', handlers.get);
-  //router.put('/' + dbName + '/1234', handlers.put);
-  //router.delete('/' + dbName + '/1234', handlers.delete);
   return router;
 }
 
-describe('test-core-resources - just the /', function() {
-  var app, router; app = express(); router = express.Router();
+describe('test-core-resources - just the /', function () {
+  var app = express();
+  var router = express.Router();
 
-  before(function() {
-    //mocker..
-    router.all('*', function(req, res, next) {
+  before(function () {
+    // mocker..
+    router.all('*', function (req, res, next) {
       req.connection.pskRole = 'repl';
       next();
-    })
-    //Norml middleware usage..0
-    var acl = require('./acl-block.1.js');
-    router.all('*', lib('foobar', acl, function(){}));
-    //mock handlers  
+    });
+    // Norml middleware usage..0
+    router.all('*', lib('foobar', acl, function (){}));
+    // mock handlers
     app.use('/', genericHandlers(router, path));
-  })
+  });
 
-  it('should be OK', function(done) {
+  it('should be OK', function (done) {
     request(app)
       .get('/')
       .set('Accept', 'application/json')
       .expect(200, done);
-  })
-})
+  });
+});
 
-describe('test-core-resources calling the /db/{id} path', function() {
-  describe('using repl identity', function() {
-    var app, router; app = express(); router = express.Router();
+describe('test-core-resources calling the /db/{id} path', function () {
+  describe('using repl identity', function () {
+    var app, router;
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
+    before(function () {
+      // mocker..
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'repl';
         next();
-      })
-      //Norml middleware usage..0
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, function(){}));
-      //mock handlers  
+      });
+      // Norml middleware usage..0
+      router.all('*', lib('foobar', acl, function (){}));
+      // mock handlers
       app.use('/', genericHandlers(router, path));
-    })
+    });
 
-    it('GET should be 200 ' + '/' + path, function(done) {
+    it('GET should be 200 ' + '/' + path, function (done) {
       request(app)
         .get('/' + path)
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-    it('PUT should be 401', function(done) {
+    });
+    it('PUT should be 401', function (done) {
       request(app)
         .put('/' + path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('DELETE should be 401', function(done) {
+    });
+    it('DELETE should be 401', function (done) {
       request(app)
         .delete('/' + path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('POST should be 401', function(done) {
+    });
+    it('POST should be 401', function (done) {
       request(app)
         .post('/' + path)
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
+    });
 
-    it('GET should be 401 on /1234/1234', function(done) {
+    it('GET should be 401 on /1234/1234', function (done) {
       request(app)
         .get('/' + path + '/1234')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('PUT should be 401', function(done) {
+    });
+    it('PUT should be 401', function (done) {
       request(app)
         .put('/' + path + '/1234')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-    it('DELETE should be 401', function(done) {
+    });
+    it('DELETE should be 401', function (done) {
       request(app)
         .delete('/' + path + '/1234')
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-  })
-})
+    });
+  });
+});

--- a/test/test-db-prefix.js
+++ b/test/test-db-prefix.js
@@ -32,7 +32,7 @@ var acl = [{
 }];
 
 describe('test-prefix.js - should let all through', function () {
-  describe('strip prefix - true', function () {
+  describe('DB prefix', function () {
     var app = express();
     var router = express.Router();
 
@@ -42,7 +42,53 @@ describe('test-prefix.js - should let all through', function () {
         next();
       });
       router.all('*', lib('foobar', acl, function (){}, {
-        prefix: 'prefix'
+        dbPrefix: 'prefix'
+      }));
+      app.use('/', genericHandlers(router));
+    });
+    it('/ should be 200', function (done) {
+      request(app)
+        .get('/')
+        .expect(200, done);
+    });
+    it('/prefix/ should be 401', function (done) {
+      request(app)
+        .get('/prefix/')
+        .expect(401, done);
+    });
+    it('/foo should be 200', function (done) {
+      request(app)
+        .get('/foo')
+        .expect(200, done);
+    });
+    it('/prefix/foo should be 401', function (done) {
+      request(app)
+        .get('/prefix/foo')
+        .expect(401, done);
+    });
+    it('/foobar/fit should be 401', function (done) {
+      request(app)
+        .get('/foobar/fit')
+        .expect(401, done);
+    });
+    it('/prefix/foobar/fit should be 200', function (done) {
+      request(app)
+        .get('/prefix/foobar/fit')
+        .expect(200, done);
+    });
+  });
+  
+  describe('DB prefix with leading slash', function () {
+    var app = express();
+    var router = express.Router();
+
+    before(function () {
+      router.all('*', function (req, res, next) {
+        req.connection.pskRole = 'user';
+        next();
+      });
+      router.all('*', lib('foobar', acl, function (){}, {
+        dbPrefix: '/prefix'
       }));
       app.use('/', genericHandlers(router));
     });
@@ -78,7 +124,7 @@ describe('test-prefix.js - should let all through', function () {
     });
   });
 
-  describe('strip trailing slash - false', function () {
+  describe('DB no prefix', function () {
     var app = express();
     var router = express.Router();
 

--- a/test/test-invalid-path.js
+++ b/test/test-invalid-path.js
@@ -54,8 +54,8 @@ describe('test-invalid-url.js - should let all through', function() {
         req.connection.pskRole = 'user';
         next();
       });
-      router.all('*', lib('foobar', acl, function(thali_id) {
-        return thali_id == 'xx';
+      router.all('*', lib('foobar', acl, function(thaliId) {
+        return thaliId == 'xx';
       }));
       app.use('/', genericHandlers(router));
     });
@@ -88,8 +88,8 @@ describe('test-invalid-url.js - should let all through', function() {
         req.connection.pskRole = 'user';
         next();
       });
-      router.all('*', lib('foobar', acl, function(thali_id) {
-        return thali_id == 'xx';
+      router.all('*', lib('foobar', acl, function(thaliId) {
+        return thaliId == 'xx';
       }));
       app.use('/', genericHandlers(router));
     });

--- a/test/test-invalid-path.js
+++ b/test/test-invalid-path.js
@@ -2,11 +2,11 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 
 function genericHandlers(router) {
   var handlers = require('./handlers2');

--- a/test/test-invalid-path.js
+++ b/test/test-invalid-path.js
@@ -1,15 +1,14 @@
 'use strict';
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var lib = require(path.join(__dirname, '../lib/index'));
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
 
 function genericHandlers(router) {
-  var handlers = require('./handlers2');
   router.get('*', handlers.get);
   return router;
 }
@@ -36,16 +35,16 @@ var acl = [{
   ]
 }];
 
-describe('test-invalid-url.js - should let all through', function() {
-  describe('no leading slash', function() {
+describe('test-invalid-url.js - should let all through', function () {
+  describe('no leading slash', function () {
     var app = express();
     var router = express.Router();
-    
+
     // Supertest doesn't like invalid urls without leading slash.
     // This can be fixed by stripping leading slash in first route filter.
-    
-    before(function() {
-      router.all('*', function(req, res, next) {
+
+    before(function () {
+      router.all('*', function (req, res, next) {
         // stripping leading slash
         if (req.url.length > 0 && req.url[0] === '/') {
           // req.url will change req.path in the next route (acl).
@@ -54,56 +53,57 @@ describe('test-invalid-url.js - should let all through', function() {
         req.connection.pskRole = 'user';
         next();
       });
-      router.all('*', lib('foobar', acl, function(thaliId) {
+      router.all('*', lib('foobar', acl, function (thaliId) {
         return thaliId == 'xx';
       }));
       app.use('/', genericHandlers(router));
     });
-    it('a should be 401', function(done) {
+    it('a should be 401', function (done) {
       request(app)
         .get('/a')
         .expect(401, done);
     });
-    it('a/b should be 401', function(done) {
+    it('a/b should be 401', function (done) {
       request(app)
         .get('/a/b')
         .expect(401, done);
     });
-    it('/foobar/_local/thali_xx should be 401', function(done) {
+    it('/foobar/_local/thali_xx should be 401', function (done) {
       request(app)
         .get('/foobar/_local/thali_xx')
         .expect(401, done);
     });
   });
-  describe('trailing whitespace', function() {
+  describe('trailing whitespace', function () {
     var app = express();
     var router = express.Router();
-    
-    // Supertest doesn't like invalid urls with trailing whitespace. It will just strip it.
+
+    // Supertest doesn't like invalid urls with trailing whitespace.
+    // It will just strip it.
     // Route filter will strip url too.
     // We can use trailing whitespace + trailing slash;
-    
-    before(function() {
-      router.all('*', function(req, res, next) {
+
+    before(function () {
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'user';
         next();
       });
-      router.all('*', lib('foobar', acl, function(thaliId) {
+      router.all('*', lib('foobar', acl, function (thaliId) {
         return thaliId == 'xx';
       }));
       app.use('/', genericHandlers(router));
     });
-    it('/a / should be 401', function(done) {
+    it('/a / should be 401', function (done) {
       request(app)
         .get('/a /')
         .expect(401, done);
     });
-    it('/a/b / should be 401', function(done) {
+    it('/a/b / should be 401', function (done) {
       request(app)
         .get('/a/b /')
         .expect(401, done);
     });
-    it('/foobar/_local/thali_ / should be 401', function(done) {
+    it('/foobar/_local/thali_ / should be 401', function (done) {
       request(app)
         .get('/foobar/_local/thali_xx /')
         .expect(401, done);

--- a/test/test-noaclfile.js
+++ b/test/test-noaclfile.js
@@ -2,11 +2,11 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 
 function genericHandlers(router) {
   var handlers = require('./handlers2');

--- a/test/test-noaclfile.js
+++ b/test/test-noaclfile.js
@@ -1,100 +1,94 @@
 'use strict';
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var lib = require(path.join(__dirname, '../lib/index'));
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
 
 function genericHandlers(router) {
-  var handlers = require('./handlers2');
   router.get('/', handlers.get);
   router.post('/', handlers.post);
   router.put('/', handlers.put);
   return router;
 }
 
-describe('test-noaclfile.js - should let all through', function() {
-  describe('simple check with NO acl - no identity', function() {
-    var app, router;
-    app = express();
-    router = express.Router();
+describe('test-noaclfile.js - should let all through', function () {
+  describe('simple check with NO acl - no identity', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      router.all('*', function(req, res, next) {
+    before(function () {
+      router.all('*', function (req, res, next) {
         next();
-      })
-
+      });
       app.use('/', genericHandlers(router));
-    })
-    it('should be 200', function(done) {
+    });
+    it('should be 200', function (done) {
       request(app)
         .get('/')
         .send({ email: 'test@test.com', password: 'password' })
         .set('Accept', 'application/json')
         .expect(200, done);
-    })
-  })
-  describe('simple check with acl - no identity', function() {
-    var app, router;
-    app = express();
-    router = express.Router();
+    });
+  });
+  describe('simple check with acl - no identity', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      router.all('*', lib('foobar', [{}],  function(){}));
+    before(function () {
+      router.all('*', lib('foobar', [{}],  function (){}));
       app.use('/', genericHandlers(router));
-    })
-    it('should be 401', function(done) {
+    });
+    it('should be 401', function (done) {
       request(app)
         .get('/')
         .expect(401, done);
-    })
-  })
-  describe('simple check with empty acl - public identity', function() {
-    var app, router;
-    app = express();
-    router = express.Router();
+    });
+  });
+  describe('simple check with empty acl - public identity', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      router.all('*', function(req, res, next) {
+    before(function () {
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'public';
         next();
-      })
-      router.all('*', lib('foobar', [{}],  function(){}));
+      });
+      router.all('*', lib('foobar', [{}],  function (){}));
       app.use('/', genericHandlers(router));
-    })
-    it('should be 401', function(done) {
+    });
+    it('should be 401', function (done) {
       request(app)
         .get('/')
         .send({ email: 'test@test.com', password: 'password' })
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-  })
-  describe('simple check with empty - user', function() {
-    var app, router;
-    app = express();
-    router = express.Router();
+    });
+  });
+  describe('simple check with empty - user', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
+    before(function () {
+      // mocker..
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'user';
         next();
-      })
-      //Norml middleware usage..
-      router.all('*', lib('foobar', [{}], function(){}));
-      //mock handlers
+      });
+      // Norml middleware usage..
+      router.all('*', lib('foobar', [{}], function (){}));
+      // mock handlers
       app.use('/', genericHandlers(router));
-    })
-    it('should be 401', function(done) {
+    });
+    it('should be 401', function (done) {
       request(app)
         .get('/')
         .send({ email: 'test@test.com', password: 'password' })
         .set('Accept', 'application/json')
         .expect(401, done);
-    })
-  })
-})
+    });
+  });
+});

--- a/test/test-parmchecks.js
+++ b/test/test-parmchecks.js
@@ -2,43 +2,43 @@
 
 /** This will do some basic parm checking */
 
-var assert = require('assert'),
-    path = require('path');
+var assert = require('assert');
 
-var lib = require(path.join(__dirname, '../lib/index'));
+var lib = require('../lib/index');
 
-describe('some parm checking', function() {
-  it('should throw exception if just 1 parm or arg1 is not a string', function(done) {
-    assert.throws(function() {
-      var tv = lib([]);
+describe('some parm checking', function () {
+  it(
+    'should throw exception if just 1 parm or arg1 is not a string',
+    function (done) {
+      assert.throws(function () {
+        var tv = lib([]);
+      });
+      done();
+    }
+  );
+  it('should throw exception when 2nd parm is not an array', function (done) {
+    assert.throws(function () {
+      var tv = lib('foobar', 'notarray', function (){});
     });
     done();
+  });
+  it(
+    'should NOT throw exception as parm 1 is string parm 2 is array',
+    function (done) {
+      var tv = lib('foobar', ['foo', 'bar'], function (){});
+      done();
+    }
+  );
 
-  })
-  it('should throw exception when 2nd parm is not an array', function(done) {
-    assert.throws(function() {
-      var tv = lib('foobar', 'notarray', function(){});
+  it('should not throw exception as parm 3 is fn', function (done){
+    var tv = lib('foobar', ['foo'], function (){});
+    done();
+  });
+
+  it('should throw exception as parm 3 is fn', function (done){
+    assert.throws(function (){
+      var tv = lib('foobar', ['foo'], 'foo');
     });
     done();
-
-  })
-  it('should NOT throw exception as parm 1 is string parm 2 is array', function(done) {
-    var tv = lib('foobar', ['foo', 'bar'], function(){});
-    done();
-
-  })
-  
-  it('should not throw exception as parm 3 is fn', function(done){
-    var tv = lib('foobar', ['foo'], function(){});
-    done();
-  })
-  
-  
-  it('should throw exception as parm 3 is fn', function(done){
-    assert.throws(function(){
-      var tv = lib('foobar', ['foo'], 'foo');  
-    })
-    done();
-  })
-  
-})
+  });
+});

--- a/test/test-parmchecks.js
+++ b/test/test-parmchecks.js
@@ -3,9 +3,9 @@
 /** This will do some basic parm checking */
 
 var assert = require('assert'),
-    fspath = require('path');
+    path = require('path');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 
 describe('some parm checking', function() {
   it('should throw exception if just 1 parm or arg1 is not a string', function(done) {

--- a/test/test-parmchecks.js
+++ b/test/test-parmchecks.js
@@ -16,28 +16,28 @@ describe('some parm checking', function () {
       done();
     }
   );
-  it('should throw exception when 2nd parm is not an array', function (done) {
+  it('should throw exception when 2nd parm is not valid acl', function (done) {
     assert.throws(function () {
       var tv = lib('foobar', 'notarray', function (){});
     });
     done();
   });
   it(
-    'should NOT throw exception as parm 1 is string parm 2 is array',
+    'should NOT throw exception as parm 1 is string parm 2 is valid acl',
     function (done) {
-      var tv = lib('foobar', ['foo', 'bar'], function (){});
+      var tv = lib('foobar', [{}], function (){});
       done();
     }
   );
 
   it('should not throw exception as parm 3 is fn', function (done){
-    var tv = lib('foobar', ['foo'], function (){});
+    var tv = lib('foobar', [{}], function (){});
     done();
   });
 
-  it('should throw exception as parm 3 is fn', function (done){
+  it('should throw exception as parm 3 is not a fn', function (done){
     assert.throws(function (){
-      var tv = lib('foobar', ['foo'], 'foo');
+      var tv = lib('foobar', [{}], 'foo');
     });
     done();
   });

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var request = require('supertest'),
-  express = require('express'),
-  fspath = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var path = require('path');
+var colors = require('colors');
+var assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 
 function genericHandlers(router) {
   var handlers = require('./handlers2');

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var request = require('supertest'),
+  express = require('express'),
+  fspath = require('path'),
+  colors = require('colors'),
+  assert = require('assert');
+
+var lib = require(fspath.join(__dirname, '../lib/index'));
+
+function genericHandlers(router) {
+  var handlers = require('./handlers2');
+  router.get('*', handlers.get);
+  return router;
+}
+
+var acl = [{
+  'role': 'user',
+  'paths': [
+    {
+      'path': '/',
+      'verbs': ['GET']
+    },
+    {
+      'path': '/foo',
+      'verbs': ['GET']
+    }
+  ]
+}];
+
+describe('test-prefix.js - should let all through', function() {
+  describe('strip prefix - true', function() {
+    var app, router;
+    app = express();
+    router = express.Router();
+
+    before(function() {
+      router.all('*', function(req, res, next) {
+        req.connection.pskRole = 'user';
+        next();
+      });
+      router.all(
+        '*',
+        lib('foobar', acl, function(){}, {
+          prefix: '/fit'
+        })
+      );
+      app.use('/', genericHandlers(router));
+    });
+    it('/ should be 200', function(done) {
+      request(app)
+        .get('/')
+        .expect(200, done);
+    });
+    it('/fit/ should be 200', function(done) {
+      request(app)
+        .get('/fit/')
+        .expect(200, done);
+    });
+    it('/foo should be 200', function(done) {
+      request(app)
+        .get('/foo')
+        .expect(200, done);
+    });
+    it('/fit/foo should be 200', function(done) {
+      request(app)
+        .get('/fit/foo')
+        .expect(200, done);
+    });
+  });
+  describe('strip trailing slash - false', function() {
+    var app, router;
+    app = express();
+    router = express.Router();
+
+    before(function() {
+      router.all('*', function(req, res, next) {
+        req.connection.pskRole = 'user';
+        next();
+      })
+      router.all(
+        '*',
+        lib('foobar', acl, function(){}, {
+          prefix: undefined
+        })
+      );
+      app.use('/', genericHandlers(router));
+    });
+    it('/ should be 200', function(done) {
+      request(app)
+        .get('/')
+        .expect(200, done);
+    });
+    it('/fit/ should be 401', function(done) {
+      request(app)
+        .get('/fit/')
+        .expect(401, done);
+    });
+    it('/foo should be 200', function(done) {
+      request(app)
+        .get('/foo')
+        .expect(200, done);
+    });
+    it('/fit/foo should be 401', function(done) {
+      request(app)
+        .get('/fit/foo')
+        .expect(401, done);
+    });
+  });
+});

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -39,31 +39,32 @@ describe('test-prefix.js - should let all through', function () {
     before(function () {
       router.all('*', function (req, res, next) {
         req.connection.pskRole = 'user';
-        req.connection.prefix  = '/prefix';
         next();
       });
-      router.all('*', lib('foobar', acl, function (){}));
+      router.all('*', lib('foobar', acl, function (){}, {
+        prefix: 'prefix'
+      }));
       app.use('/', genericHandlers(router));
     });
-    it('/ should be 401', function (done) {
+    it('/ should be 200', function (done) {
       request(app)
         .get('/')
-        .expect(401, done);
+        .expect(200, done);
     });
-    it('/prefix/ should be 200', function (done) {
+    it('/prefix/ should be 401', function (done) {
       request(app)
         .get('/prefix/')
-        .expect(200, done);
-    });
-    it('/foo should be 401', function (done) {
-      request(app)
-        .get('/foo')
         .expect(401, done);
     });
-    it('/prefix/foo should be 200', function (done) {
+    it('/foo should be 200', function (done) {
+      request(app)
+        .get('/foo')
+        .expect(200, done);
+    });
+    it('/prefix/foo should be 401', function (done) {
       request(app)
         .get('/prefix/foo')
-        .expect(200, done);
+        .expect(401, done);
     });
     it('/foobar/fit should be 401', function (done) {
       request(app)
@@ -76,6 +77,7 @@ describe('test-prefix.js - should let all through', function () {
         .expect(200, done);
     });
   });
+
   describe('strip trailing slash - false', function () {
     var app = express();
     var router = express.Router();
@@ -108,12 +110,12 @@ describe('test-prefix.js - should let all through', function () {
         .get('/prefix/foo')
         .expect(401, done);
     });
-    it('/foobar/fit should be 401', function (done) {
+    it('/foobar/fit should be 200', function (done) {
       request(app)
         .get('/foobar/fit')
         .expect(200, done);
     });
-    it('/prefix/foobar/fit should be 200', function (done) {
+    it('/prefix/foobar/fit should be 401', function (done) {
       request(app)
         .get('/prefix/foobar/fit')
         .expect(401, done);

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -39,14 +39,10 @@ describe('test-prefix.js - should let all through', function () {
     before(function () {
       router.all('*', function (req, res, next) {
         req.connection.pskRole = 'user';
+        req.connection.prefix  = '/prefix';
         next();
       });
-      router.all(
-        '*',
-        lib('foobar', acl, function (){}, {
-          prefix: '/prefix'
-        })
-      );
+      router.all('*', lib('foobar', acl, function (){}));
       app.use('/', genericHandlers(router));
     });
     it('/ should be 401', function (done) {
@@ -89,12 +85,7 @@ describe('test-prefix.js - should let all through', function () {
         req.connection.pskRole = 'user';
         next();
       });
-      router.all(
-        '*',
-        lib('foobar', acl, function (){}, {
-          prefix: undefined
-        })
-      );
+      router.all('*', lib('foobar', acl, function (){}));
       app.use('/', genericHandlers(router));
     });
     it('/ should be 200', function (done) {

--- a/test/test-thali-callback.js
+++ b/test/test-thali-callback.js
@@ -6,42 +6,117 @@ var request = require('supertest'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
 
-function genericHandlers(router) {
+var lib = require(fspath.join(__dirname, '../lib/index'));
+var dbName = 'foobar';
+var pathPrefix = '/' + dbName + '/_local/thali__ID_';
+
+var validId = 'zz-xx--bb';
+
+
+function verifyThaliUser(idToCheck) {
+  console.log(colors.green('checking ID: %s'), idToCheck);
+  return validId === idToCheck;
+}
+
+function genericHandlers(router, path) {
   var handlers = require('./handlers2');
-  router.get('*', handlers.get);
+  router.get(path, handlers.get);
+  router.post(path, handlers.post);
+  router.put(path, handlers.put);
+  router.head(path, handlers.head);
+  router.options(path, handlers.options);
+  router.delete(path, handlers.options);
   return router;
 }
 
-var acl = [{
-  'role': 'user',
-  'paths': [
-    {
-      'path': '/{:db}/_local/{:id}',
-      'verbs': ['GET']
-    },
-    {
-      'path': '/{:db}/_local/thali_{:id}',
-      'verbs': ['GET']
-    }
-  ]
-}];
+describe('We are validating requests that look like /db/_local/thali_:ID', function() {
+  describe('if the request is ../thali_ and nothing', function(done) {
+    var app, router; app = express(); router = express.Router();
 
-describe('test-thali-callback.js - should let all through', function() {
+    var rootPath = '/' + dbName + '/_local/thali_';
+    var pathWithId = rootPath + validId;
+
+    before(function() {
+      //mocker..
+      router.all('*', function(req, res, next) {
+        req.connection.pskRole = 'repl';
+        next();
+      })
+      //Norml middleware usage..0
+      var acl = require('./acl-block.1.js');
+      router.all('*', lib('foobar', acl, verifyThaliUser));
+      //mock handlers
+      app.use('/', genericHandlers(router, pathWithId));
+    });
+
+    /** mapped paths mix of verbs */
+    it('GET should be OK - we are using ' + validId, function(done) {
+      request(app)
+        .get(pathWithId)
+        .set('Accept', 'application/json')
+        .expect(200, done);
+    });
+    it('GET should fail as it does not match valid ID ' + rootPath + 'zzz', function(done) {
+      request(app)
+        .get(rootPath + 'zzz')
+        .set('Accept', 'application/json')
+        .expect(401, done);
+    });
+    it('GET should fail as it does not match valid ID ' + rootPath, function(done) {
+      request(app)
+        .get(rootPath)
+        .set('Accept', 'application/json')
+        .expect(401, done);
+    });
+    it('PUT should be OK - we are using ' + validId, function(done) {
+      request(app)
+        .put(pathWithId)
+        .set('Accept', 'application/json')
+        .expect(200, done);
+    });
+    it('DELETE should be OK - we are using ' + validId, function(done) {
+      request(app)
+        .delete(pathWithId)
+        .set('Accept', 'application/json')
+        .expect(200, done);
+    });
+    it('POST should fail no acl for verb  - we are using ' + validId, function(done) {
+      request(app)
+        .post(pathWithId)
+        .set('Accept', 'application/json')
+        .expect(401, done);
+    });
+
+    /** unmapped paths */
+    it('should fail with a 401 as not valid', function(done) {
+      request(app)
+        .get(rootPath)
+        .set('Accept', 'application/json')
+        .expect(401, done);
+    });
+    
+    it('should OK as full path', function(done) {
+      request(app)
+        .get(pathWithId)
+        .set('Accept', 'application/json')
+        .expect(200, done);
+    });
+  });
   describe('req should be passed to callback', function() {
     var app = express();
     var router = express.Router();
     
     before(function() {
       router.all('*', function(req, res, next) {
-        req.connection.pskRole = 'user';
+        req.connection.pskRole = 'repl';
         next();
       });
+      var acl = require('./acl-block.1.js');
       router.all('*', lib('foobar', acl, function(thaliId, req) {
-        return thaliId == 'xx' && req.connection.pskRole === 'user';
+        return thaliId == 'xx' && req.connection.pskRole === 'repl';
       }));
-      app.use('/', genericHandlers(router));
+      app.use('/', genericHandlers(router, '*'));
     });
     it('/foobar/_local/xx should be 200', function(done) {
       request(app)

--- a/test/test-thali-callback.js
+++ b/test/test-thali-callback.js
@@ -2,12 +2,12 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var pathPrefix = '/' + dbName + '/_local/thali__ID_';
 

--- a/test/test-thali-callback.js
+++ b/test/test-thali-callback.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
+var acl = require('./acl-block.1.js');
 
-var lib = require(path.join(__dirname, '../lib/index'));
 var dbName = 'foobar';
 var pathPrefix = '/' + dbName + '/_local/thali__ID_';
 
 var validId = 'zz-xx--bb';
-
 
 function verifyThaliUser(idToCheck) {
   console.log(colors.green('checking ID: %s'), idToCheck);
@@ -20,7 +20,6 @@ function verifyThaliUser(idToCheck) {
 }
 
 function genericHandlers(router, path) {
-  var handlers = require('./handlers2');
   router.get(path, handlers.get);
   router.post(path, handlers.post);
   router.put(path, handlers.put);
@@ -30,103 +29,114 @@ function genericHandlers(router, path) {
   return router;
 }
 
-describe('We are validating requests that look like /db/_local/thali_:ID', function() {
-  describe('if the request is ../thali_ and nothing', function(done) {
-    var app, router; app = express(); router = express.Router();
+describe(
+  'We are validating requests that look like /db/_local/thali_:ID',
+  function () {
+    describe('if the request is ../thali_ and nothing', function () {
+      var app, router; app = express(); router = express.Router();
 
-    var rootPath = '/' + dbName + '/_local/thali_';
-    var pathWithId = rootPath + validId;
+      var rootPath = '/' + dbName + '/_local/thali_';
+      var pathWithId = rootPath + validId;
 
-    before(function() {
-      //mocker..
-      router.all('*', function(req, res, next) {
-        req.connection.pskRole = 'repl';
-        next();
-      })
-      //Norml middleware usage..0
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, verifyThaliUser));
-      //mock handlers
-      app.use('/', genericHandlers(router, pathWithId));
-    });
-
-    /** mapped paths mix of verbs */
-    it('GET should be OK - we are using ' + validId, function(done) {
-      request(app)
-        .get(pathWithId)
-        .set('Accept', 'application/json')
-        .expect(200, done);
-    });
-    it('GET should fail as it does not match valid ID ' + rootPath + 'zzz', function(done) {
-      request(app)
-        .get(rootPath + 'zzz')
-        .set('Accept', 'application/json')
-        .expect(401, done);
-    });
-    it('GET should fail as it does not match valid ID ' + rootPath, function(done) {
-      request(app)
-        .get(rootPath)
-        .set('Accept', 'application/json')
-        .expect(401, done);
-    });
-    it('PUT should be OK - we are using ' + validId, function(done) {
-      request(app)
-        .put(pathWithId)
-        .set('Accept', 'application/json')
-        .expect(200, done);
-    });
-    it('DELETE should be OK - we are using ' + validId, function(done) {
-      request(app)
-        .delete(pathWithId)
-        .set('Accept', 'application/json')
-        .expect(200, done);
-    });
-    it('POST should fail no acl for verb  - we are using ' + validId, function(done) {
-      request(app)
-        .post(pathWithId)
-        .set('Accept', 'application/json')
-        .expect(401, done);
-    });
-
-    /** unmapped paths */
-    it('should fail with a 401 as not valid', function(done) {
-      request(app)
-        .get(rootPath)
-        .set('Accept', 'application/json')
-        .expect(401, done);
-    });
-    
-    it('should OK as full path', function(done) {
-      request(app)
-        .get(pathWithId)
-        .set('Accept', 'application/json')
-        .expect(200, done);
-    });
-  });
-  describe('req should be passed to callback', function() {
-    var app = express();
-    var router = express.Router();
-    
-    before(function() {
-      router.all('*', function(req, res, next) {
-        req.connection.pskRole = 'repl';
-        next();
+      before(function () {
+        // mocker..
+        router.all('*', function (req, res, next) {
+          req.connection.pskRole = 'repl';
+          next();
+        });
+        // Norml middleware usage..0
+        router.all('*', lib('foobar', acl, verifyThaliUser));
+        // mock handlers
+        app.use('/', genericHandlers(router, pathWithId));
       });
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, function(thaliId, req) {
-        return thaliId == 'xx' && req.connection.pskRole === 'repl';
-      }));
-      app.use('/', genericHandlers(router, '*'));
+
+      // mapped paths mix of verbs
+      it('GET should be OK - we are using ' + validId, function (done) {
+        request(app)
+          .get(pathWithId)
+          .set('Accept', 'application/json')
+          .expect(200, done);
+      });
+      it(
+        'GET should fail as it does not match valid ID ' + rootPath + 'zzz',
+        function (done) {
+          request(app)
+            .get(rootPath + 'zzz')
+            .set('Accept', 'application/json')
+            .expect(401, done);
+        }
+      );
+      it(
+        'GET should fail as it does not match valid ID ' + rootPath,
+        function (done) {
+          request(app)
+            .get(rootPath)
+            .set('Accept', 'application/json')
+            .expect(401, done);
+        }
+      );
+      it('PUT should be OK - we are using ' + validId, function (done) {
+        request(app)
+          .put(pathWithId)
+          .set('Accept', 'application/json')
+          .expect(200, done);
+      });
+      it('DELETE should be OK - we are using ' + validId, function (done) {
+        request(app)
+          .delete(pathWithId)
+          .set('Accept', 'application/json')
+          .expect(200, done);
+      });
+      it(
+        'POST should fail no acl for verb  - we are using ' + validId,
+        function (done) {
+          request(app)
+            .post(pathWithId)
+            .set('Accept', 'application/json')
+            .expect(401, done);
+        }
+      );
+
+      // unmapped paths
+      it('should fail with a 401 as not valid', function (done) {
+        request(app)
+          .get(rootPath)
+          .set('Accept', 'application/json')
+          .expect(401, done);
+      });
+
+      it('should OK as full path', function (done) {
+        request(app)
+          .get(pathWithId)
+          .set('Accept', 'application/json')
+          .expect(200, done);
+      });
     });
-    it('/foobar/_local/xx should be 200', function(done) {
-      request(app)
-        .get('/foobar/_local/xx')
-        .expect(200, done);
+    describe('req should be passed to callback', function () {
+      var app = express();
+      var router = express.Router();
+
+      before(function () {
+        router.all('*', function (req, res, next) {
+          req.connection.pskRole = 'repl';
+          next();
+        });
+        var acl = require('./acl-block.1.js');
+        router.all('*', lib('foobar', acl, function (thaliId, req) {
+          return thaliId == 'xx' && req.connection.pskRole === 'repl';
+        }));
+        app.use('/', genericHandlers(router, '*'));
+      });
+      it('/foobar/_local/xx should be 200', function (done) {
+        request(app)
+          .get('/foobar/_local/xx')
+          .expect(200, done);
+      });
+      it('/foobar/_local/thali_xx should be 200', function (done) {
+        request(app)
+          .get('/foobar/_local/thali_xx')
+          .expect(200, done);
+      });
     });
-    it('/foobar/_local/thali_xx should be 200', function(done) {
-      request(app)
-        .get('/foobar/_local/thali_xx')
-        .expect(200, done);
-    });
-  });
-});
+  }
+);

--- a/test/test-thali-callback.js
+++ b/test/test-thali-callback.js
@@ -6,101 +6,52 @@ var request = require('supertest'),
   colors = require('colors'),
   assert = require('assert');
 
-
 var lib = require(fspath.join(__dirname, '../lib/index'));
-var dbName = 'foobar';
-var pathPrefix = '/' + dbName + '/_local/thali__ID_';
 
-var validId = 'zz-xx--bb';
-
-
-function verifyThaliUser(idToCheck) {
-  console.log(colors.green('checking ID: %s'), idToCheck);
-  return validId === idToCheck;
-}
-
-function genericHandlers(router, path) {
+function genericHandlers(router) {
   var handlers = require('./handlers2');
-  router.get(path, handlers.get);
-  router.post(path, handlers.post);
-  router.put(path, handlers.put);
-  router.head(path, handlers.head);
-  router.options(path, handlers.options);
-  router.delete(path, handlers.options);
+  router.get('*', handlers.get);
   return router;
 }
 
-describe('We are validating requests that look like /db/_local/thali_:ID', function() {
-  describe('if the request is ../thali_ and nothing', function(done) {
-    var app, router; app = express(); router = express.Router();
+var acl = [{
+  'role': 'user',
+  'paths': [
+    {
+      'path': '/{:db}/_local/{:id}',
+      'verbs': ['GET']
+    },
+    {
+      'path': '/{:db}/_local/thali_{:id}',
+      'verbs': ['GET']
+    }
+  ]
+}];
 
-    var rootPath = '/' + dbName + '/_local/thali_';
-    var pathWithId = rootPath + validId;
-
+describe('test-thali-callback.js - should let all through', function() {
+  describe('req should be passed to callback', function() {
+    var app = express();
+    var router = express.Router();
+    
     before(function() {
-      //mocker..
       router.all('*', function(req, res, next) {
-        req.connection.pskRole = 'repl';
+        req.connection.pskRole = 'user';
         next();
-      })
-      //Norml middleware usage..0
-      var acl = require('./acl-block.1.js');
-      router.all('*', lib('foobar', acl, verifyThaliUser));
-      //mock handlers
-      app.use('/', genericHandlers(router, pathWithId));
-    })
-
-    /** mapped paths mix of verbs */
-    it('GET should be OK - we are using ' + validId, function(done) {
+      });
+      router.all('*', lib('foobar', acl, function(thaliId, req) {
+        return thaliId == 'xx' && req.connection.pskRole === 'user';
+      }));
+      app.use('/', genericHandlers(router));
+    });
+    it('/foobar/_local/xx should be 200', function(done) {
       request(app)
-        .get(pathWithId)
-        .set('Accept', 'application/json')
+        .get('/foobar/_local/xx')
         .expect(200, done);
-    })
-    it('GET should fail as it does not match valid ID ' + rootPath + 'zzz', function(done) {
+    });
+    it('/foobar/_local/thali_xx should be 200', function(done) {
       request(app)
-        .get(rootPath + 'zzz')
-        .set('Accept', 'application/json')
-        .expect(401, done);
-    })
-    it('GET should fail as it does not match valid ID ' + rootPath, function(done) {
-      request(app)
-        .get(rootPath)
-        .set('Accept', 'application/json')
-        .expect(401, done);
-    })
-    it('PUT should be OK - we are using ' + validId, function(done) {
-      request(app)
-        .put(pathWithId)
-        .set('Accept', 'application/json')
+        .get('/foobar/_local/thali_xx')
         .expect(200, done);
-    })
-    it('DELETE should be OK - we are using ' + validId, function(done) {
-      request(app)
-        .delete(pathWithId)
-        .set('Accept', 'application/json')
-        .expect(200, done);
-    })
-   it('POST should fail no acl for verb  - we are using ' + validId, function(done) {
-      request(app)
-        .post(pathWithId)
-        .set('Accept', 'application/json')
-        .expect(401, done);
-    })
-
-    /** unmapped paths */
-    it('should fail with a 401 as not valid', function(done) {
-      request(app)
-        .get(rootPath)
-        .set('Accept', 'application/json')
-        .expect(401, done);
-    })
-
-    it('should OK as full path', function(done) {
-      request(app)
-        .get(pathWithId)
-        .set('Accept', 'application/json')
-        .expect(200, done);
-    })
-  })
-})
+    });
+  });
+});

--- a/test/test-trailing-slash.js
+++ b/test/test-trailing-slash.js
@@ -2,11 +2,11 @@
 
 var request = require('supertest'),
   express = require('express'),
-  fspath = require('path'),
+  path = require('path'),
   colors = require('colors'),
   assert = require('assert');
 
-var lib = require(fspath.join(__dirname, '../lib/index'));
+var lib = require(path.join(__dirname, '../lib/index'));
 
 function genericHandlers(router) {
   var handlers = require('./handlers2');

--- a/test/test-trailing-slash.js
+++ b/test/test-trailing-slash.js
@@ -1,15 +1,14 @@
 'use strict';
 
-var request = require('supertest'),
-  express = require('express'),
-  path = require('path'),
-  colors = require('colors'),
-  assert = require('assert');
+var request = require('supertest');
+var express = require('express');
+var colors = require('colors');
+var assert = require('assert');
 
-var lib = require(path.join(__dirname, '../lib/index'));
+var handlers = require('./handlers2');
+var lib = require('../lib/index');
 
 function genericHandlers(router) {
-  var handlers = require('./handlers2');
   router.get('*', handlers.get);
   return router;
 }
@@ -32,123 +31,131 @@ var acl = [{
   ]
 }];
 
-describe('test-trailing-slash.js - should let all through', function() {
-  describe('strip trailing slash - true', function() {
-    var app, router;
-    app = express();
-    router = express.Router();
+describe('test-trailing-slash.js - should let all through', function () {
+  describe('strip trailing slash - true', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      router.all('*', function(req, res, next) {
+    before(function () {
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'user';
         next();
-      })
-      router.all('*', lib('foobar', acl, function(){}, { stripTrailingSlash: true }));
+      });
+      router.all(
+        '*',
+        lib('foobar', acl, function (){}, {
+          stripTrailingSlash: true
+        })
+      );
       app.use('/', genericHandlers(router));
-    })
-    it('/ should be 200', function(done) {
+    });
+    it('/ should be 200', function (done) {
       request(app)
         .get('/')
         .expect(200, done);
-    })
-    it('/\/ should be 200', function(done) {
+    });
+    it('/\/ should be 200', function (done) {
       request(app)
         .get('/\/')
         .expect(200, done);
-    })
-    it('/%2F should be 401', function(done) {
+    });
+    it('/%2F should be 401', function (done) {
       request(app)
         .get('/%2F')
         .expect(401, done);
-    })
-    it('/foo should be 200', function(done) {
+    });
+    it('/foo should be 200', function (done) {
       request(app)
         .get('/foo')
         .expect(200, done);
-    })
-    it('/foo/ should be 200', function(done) {
+    });
+    it('/foo/ should be 200', function (done) {
       request(app)
         .get('/foo/')
         .expect(200, done);
-    })
-    it('/foo%2F should be 401', function(done) {
+    });
+    it('/foo%2F should be 401', function (done) {
       request(app)
         .get('/foo%2F')
         .expect(401, done);
-    })
-    it('/bar should be 401', function(done) {
+    });
+    it('/bar should be 401', function (done) {
       request(app)
         .get('/bar')
         .expect(401, done);
-    })
-    it('/bar/ should be 401', function(done) {
+    });
+    it('/bar/ should be 401', function (done) {
       request(app)
         .get('/bar/')
         .expect(401, done);
-    })
-    it('/bar%2F should be 401', function(done) {
+    });
+    it('/bar%2F should be 401', function (done) {
       request(app)
         .get('/bar%2F')
         .expect(401, done);
-    })
+    });
   });
-  describe('strip trailing slash - false', function() {
-    var app, router;
-    app = express();
-    router = express.Router();
+  describe('strip trailing slash - false', function () {
+    var app = express();
+    var router = express.Router();
 
-    before(function() {
-      router.all('*', function(req, res, next) {
+    before(function () {
+      router.all('*', function (req, res, next) {
         req.connection.pskRole = 'user';
         next();
-      })
-      router.all('*', lib('foobar', acl, function(){}, { stripTrailingSlash: false }));
+      });
+      router.all(
+        '*',
+        lib('foobar', acl, function (){}, {
+          stripTrailingSlash: false
+        })
+      );
       app.use('/', genericHandlers(router));
-    })
-    it('/ should be 200', function(done) {
+    });
+    it('/ should be 200', function (done) {
       request(app)
         .get('/')
         .expect(200, done);
-    })
-    it('/\/ should be 401', function(done) {
+    });
+    it('/\/ should be 401', function (done) {
       request(app)
         .get('/\/')
         .expect(401, done);
-    })
-    it('/%2F should be 401', function(done) {
+    });
+    it('/%2F should be 401', function (done) {
       request(app)
         .get('/%2F')
         .expect(401, done);
-    })
-    it('/foo should be 200', function(done) {
+    });
+    it('/foo should be 200', function (done) {
       request(app)
         .get('/foo')
         .expect(200, done);
-    })
-    it('/foo/ should be 401', function(done) {
+    });
+    it('/foo/ should be 401', function (done) {
       request(app)
         .get('/foo/')
         .expect(401, done);
-    })
-    it('/foo%2F should be 401', function(done) {
+    });
+    it('/foo%2F should be 401', function (done) {
       request(app)
         .get('/foo%2F')
         .expect(401, done);
-    })
-    it('/bar should be 401', function(done) {
+    });
+    it('/bar should be 401', function (done) {
       request(app)
         .get('/bar')
         .expect(401, done);
-    })
-    it('/bar/ should be 200', function(done) {
+    });
+    it('/bar/ should be 200', function (done) {
       request(app)
         .get('/bar/')
         .expect(200, done);
-    })
-    it('/bar%2F should be 401', function(done) {
+    });
+    it('/bar%2F should be 401', function (done) {
       request(app)
         .get('/bar%2F')
         .expect(401, done);
-    })
+    });
   });
 });


### PR DESCRIPTION
1. Added schema check.
2. Path resolution simplified.
3. Removed irrational regexp from thali id.
4. Both DB name and prefix has been cutted before actual path check. It shouldn't create any problem in future with any spec #9.

I think this closes previous problem with db prefix. Closes #10

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/salti/11)

<!-- Reviewable:end -->

<!---
@huboard:{"order":2.9780038650127233e-08,"milestone_order":11,"custom_state":""}
-->
